### PR TITLE
Add dummy data

### DIFF
--- a/Doppler.Sap/Models/SapConfig.cs
+++ b/Doppler.Sap/Models/SapConfig.cs
@@ -9,5 +9,6 @@ namespace Doppler.Sap.Models
         public string SlackAlertUrl { get; set; }
         public int MaxAmountAllowedAccounts { get; set; }
         public int SessionTimeoutPadding { get; set; }
+        public bool UseDummyData { get; set; }
     }
 }

--- a/Doppler.Sap/Services/DummyBillingService.cs
+++ b/Doppler.Sap/Services/DummyBillingService.cs
@@ -1,0 +1,19 @@
+using Doppler.Sap.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Doppler.Sap.Services
+{
+    public class DummyBillingService : IBillingService
+    {
+        public Task SendCurrencyToSap(List<CurrencyRateDto> currencyRate)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task CreateBillingRequest(List<BillingRequest> billingRequests)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Doppler.Sap/Services/DummyBusinessPartnerService.cs
+++ b/Doppler.Sap/Services/DummyBusinessPartnerService.cs
@@ -1,0 +1,13 @@
+using Doppler.Sap.Models;
+using System.Threading.Tasks;
+
+namespace Doppler.Sap.Services
+{
+    public class DummyBusinessPartnerService : IBusinessPartnerService
+    {
+        public Task CreateOrUpdateBusinessPartner(DopplerUserDto dopplerUser)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Doppler.Sap/Services/ServicesCollectionExtensions.cs
+++ b/Doppler.Sap/Services/ServicesCollectionExtensions.cs
@@ -1,0 +1,15 @@
+using Doppler.Sap.Models;
+using Doppler.Sap.Services;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServicesCollectionExtensions
+    {
+        public static void AddSapServices(this IServiceCollection services)
+        {
+            services.AddTransient<IBillingService, BillingService>();
+            services.AddTransient<IBusinessPartnerService, BusinessPartnerService>();
+        }
+    }
+}

--- a/Doppler.Sap/Services/ServicesCollectionExtensions.cs
+++ b/Doppler.Sap/Services/ServicesCollectionExtensions.cs
@@ -8,8 +8,28 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static void AddSapServices(this IServiceCollection services)
         {
-            services.AddTransient<IBillingService, BillingService>();
-            services.AddTransient<IBusinessPartnerService, BusinessPartnerService>();
+            services.AddSingleton<DummyBillingService>();
+            services.AddTransient<BillingService>();
+            services.AddSingleton<DummyBusinessPartnerService>();
+            services.AddTransient<BusinessPartnerService>();
+
+            services.AddTransient<IBillingService>(serviceProvider =>
+            {
+                var sapProviderOptions = serviceProvider.GetRequiredService<IOptions<SapConfig>>();
+
+                return sapProviderOptions.Value.UseDummyData
+                    ? (IBillingService)serviceProvider.GetRequiredService<DummyBillingService>()
+                    : serviceProvider.GetRequiredService<BillingService>();
+            });
+
+            services.AddTransient<IBusinessPartnerService>(serviceProvider =>
+            {
+                var sapProviderOptions = serviceProvider.GetRequiredService<IOptions<SapConfig>>();
+
+                return sapProviderOptions.Value.UseDummyData
+                    ? (IBusinessPartnerService)serviceProvider.GetRequiredService<DummyBusinessPartnerService>()
+                    : serviceProvider.GetRequiredService<BusinessPartnerService>();
+            });
         }
     }
 }

--- a/Doppler.Sap/Startup.cs
+++ b/Doppler.Sap/Startup.cs
@@ -76,9 +76,8 @@ namespace Doppler.Sap
                     ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
                     UseCookies = false
                 });
+            services.AddSapServices();
             services.AddTransient<ISapTaskHandler, SapTaskHandler>();
-            services.AddTransient<IBillingService, BillingService>();
-            services.AddTransient<IBusinessPartnerService, BusinessPartnerService>();
             services.AddSingleton<IQueuingService, QueuingService>();
             services.AddTransient<ISapService, SapService>();
             services.Configure<SapConfig>(Configuration.GetSection(nameof(SapConfig)));

--- a/Doppler.Sap/appsettings.Development.json
+++ b/Doppler.Sap/appsettings.Development.json
@@ -7,6 +7,7 @@
     }
   },
   "SapConfig": {
-    "CompanyDB": "MK_ARG_TEST"
+    "CompanyDB": "MK_ARG_TEST",
+    "UseDummyData": true
   }
 }

--- a/Doppler.Sap/appsettings.int.json
+++ b/Doppler.Sap/appsettings.int.json
@@ -1,5 +1,6 @@
 {
   "SapConfig": {
-    "CompanyDB": "MK_ARG_TEST"
+    "CompanyDB": "MK_ARG_TEST",
+    "UseDummyData": true
   }
 }

--- a/Doppler.Sap/appsettings.qa.json
+++ b/Doppler.Sap/appsettings.qa.json
@@ -1,5 +1,6 @@
 {
   "SapConfig": {
-    "CompanyDB": "MK_ARG_TEST"
+    "CompanyDB": "MK_ARG_TEST",
+    "UseDummyData": true
   }
 }


### PR DESCRIPTION
Dummy services for billing and business partner controllers were added to avoid VPN connection errors for qa and int environments