### PR TITLE
DAT-177-add-issu-permission

### DIFF
--- a/Doppler.Sap.Test/Doppler.Sap.Test.csproj
+++ b/Doppler.Sap.Test/Doppler.Sap.Test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.7" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Doppler.Sap.Test/IsSuAuthorizationPolicyTest.cs
+++ b/Doppler.Sap.Test/IsSuAuthorizationPolicyTest.cs
@@ -1,0 +1,53 @@
+using Billing.API.Test;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Newtonsoft.Json;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Doppler.Sap.Test
+{
+    public class IsSuAuthorizationPolicyTest : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private readonly WebApplicationFactory<Startup> _factory;
+
+        public IsSuAuthorizationPolicyTest(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Theory]
+        // isSU: true
+        [InlineData(HttpStatusCode.OK, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE1OTc3NjQ1MjIsImV4cCI6MTU5Nzc2NDUzMiwiaWF0IjoxNTk3NzY0NTIyLCJpc1NVIjp0cnVlfQ.j1qzmKcnpCCBoXAtK9QuzCcnkIedK_kpwlrQ315VX_bwuxNxDBeEgKCOcjACUaNnf92bStGVYxXusSlnCgWApjlFG4TRgcTNsBC_87ZMuTgjP92Ou_IHi5UVDkiIyeQ3S_-XpYGFksgzI6LhSXu2T4LZLlYUHzr6GN68QWvw19m1yw6LdrNklO5qpwARR4WEJVK-0dw2-t4V9jK2kR8zFkTYtDUFPEQaRXFBpaPWAdI1p_Dk_QDkeBbmN_vTNkF7JwmqXRRAaz5fiMmcgzFmayJFbM0Y9LUeaAYFSZytIiYZuNitVixWZEcXT_jwtfHpyDwZKY1-HlyMmUJJuVsf2A")]
+        // "isSU": false
+        [InlineData(HttpStatusCode.Forbidden, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE1OTc3NjQ3MDksImV4cCI6MTU5Nzc2NDcxOSwiaWF0IjoxNTk3NzY0NzA5LCJpc1NVIjpmYWxzZX0.K7khi_qhvj0eF3ahZzNcRkzrRPDFR_q-5xAujSeFG3GaFhJIhgARX7fsA4iPPhTJtFA1oqF54d-vyNhGAhBDFzSKUHyRegdRJ5FiQwcQ537PbZUfCc702sEi-MjzfpkP1PZrk0Zrn5-ybUDJi-6qjia8_YxvA4px8KGPT10Z6PnrpeCuWtESmMlSre7CgCRpydXZ0XkV0hsn-CD8p5oSV9iMCXS3npJBBhzLvw9B_LienlnJQMVs88ykSDqZNUWdGMVTO4QF4JChd67W7B9I0MmmbtgCZ5yo0EwykYR6RaZYihtKjesmHlBcFaHJc1C-3V8TQ3L0-81PpemqZd_3yQ")]
+        // without isSU
+        [InlineData(HttpStatusCode.Forbidden, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE2MDUwMjIxNDMsImV4cCI6MTYwNTAyMjIwMSwiaWF0IjoxNjA1MDIyMTQzfQ.j9rYDxZZ2EQ_twu8-KrkF9TZbKwh6BgLYkc8gtjFRt0jFl3in5DzDN_0qxsbcMcHyLtFus8HfnmXjFj9bZbUD2AOijPtAD3McMoQfBQS5YF4Kp-coAnweKTp_3mEW4slPqM_OBMbkRP4n1xux90p3YeJ-pYwWC3v7t1ddGWO2BHInRVb1ztcpyYWal9h3TfNyUexrRHhxW74qP59CXjl7vqsBFBeLEUky79-dGIHRhECSG4zaHiMYvFY9X7em2ERCENF0mQrCZYPxjDXWDlEuPH2tKRXEGFXHGwoaM7ZnH07_bx3ngUhjtvsjjUtDDQ6lwJMvbQODj1ANtAl-YL8ow")]
+        public async Task CreateOrUpdateBusinessPartner_WhenToken_ReturnsResponse(HttpStatusCode httpStatusCode, string token)
+        {
+            using var appFactory = _factory.WithDisabledLifeTimeValidation();
+            var client = appFactory.CreateClient();
+            var businessPartner = new
+            {
+                BillingCountryCode = "AR",
+                FederalTaxID = "27111111115",
+                PlanType = 1
+            };
+
+            var requestContent = new StringContent(JsonConvert.SerializeObject(businessPartner), Encoding.UTF8, "application/json");
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"https://localhost:5001/BusinessPartner/CreateOrUpdateBusinessPartner");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            request.Content = requestContent;
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(httpStatusCode, response.StatusCode);
+        }
+    }
+}

--- a/Doppler.Sap.Test/WebApplicationFactoryHelper.cs
+++ b/Doppler.Sap.Test/WebApplicationFactoryHelper.cs
@@ -1,0 +1,28 @@
+using Doppler.Sap;
+using Doppler.Sap.DopplerSecurity;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Billing.API.Test
+{
+    public static class WebApplicationFactoryHelper
+    {
+        public static WebApplicationFactory<Startup> ConfigureService<TOptions>(this WebApplicationFactory<Startup> factory, Action<TOptions> configureOptions) where TOptions : class
+            => factory.WithWebHostBuilder(
+                builder => builder.ConfigureTestServices(
+                    services => services.Configure(configureOptions)));
+
+        public static WebApplicationFactory<Startup> ConfigureSecurityOptions(this WebApplicationFactory<Startup> factory, Action<DopplerSecurityOptions> configureOptions)
+            => factory.ConfigureService(configureOptions);
+
+        public static WebApplicationFactory<Startup> WithDisabledLifeTimeValidation(this WebApplicationFactory<Startup> factory)
+            => factory.ConfigureSecurityOptions(
+                o => o.SkipLifetimeValidation = true);
+    }
+}

--- a/Doppler.Sap/DopplerSecurity/DopplerSecurityServiceCollectionExtensions.cs
+++ b/Doppler.Sap/DopplerSecurity/DopplerSecurityServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ namespace Doppler.Sap.DopplerSecurity
         public static IServiceCollection AddDopplerSecurity(this IServiceCollection services)
         {
             services.ConfigureOptions<ConfigureDopplerSecurityOptions>();
+            services.AddSingleton<IAuthorizationHandler, IsSuperUserHandler>();
 
             services
                 .AddOptions<AuthorizationOptions>()
@@ -19,6 +20,7 @@ namespace Doppler.Sap.DopplerSecurity
                     o.DefaultPolicy = new AuthorizationPolicyBuilder()
                         .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
                         .RequireAuthenticatedUser()
+                        .AddRequirements(new IsSuperUserRequirement())
                         .Build();
                 });
 

--- a/Doppler.Sap/DopplerSecurity/IsSuperUserHandler.cs
+++ b/Doppler.Sap/DopplerSecurity/IsSuperUserHandler.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace Doppler.Sap.DopplerSecurity
+{
+    public class IsSuperUserHandler : AuthorizationHandler<IsSuperUserRequirement>
+    {
+        private readonly ILogger<IsSuperUserHandler> _logger;
+
+        public IsSuperUserHandler(ILogger<IsSuperUserHandler> logger)
+        {
+            _logger = logger;
+        }
+
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, IsSuperUserRequirement requirement)
+        {
+            if (IsSuperUser(context))
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private bool IsSuperUser(AuthorizationHandlerContext context)
+        {
+            if (!context.User.HasClaim(c => c.Type.Equals("isSU")))
+            {
+                _logger.LogDebug("The token hasn't super user permissions.");
+                return false;
+            }
+
+            var isSuperUser = bool.Parse(context.User.FindFirst(c => c.Type.Equals("isSU")).Value);
+            if (isSuperUser)
+            {
+                return true;
+            }
+
+            _logger.LogDebug("The token super user permissions is false.");
+            return false;
+        }
+    }
+}

--- a/Doppler.Sap/DopplerSecurity/IsSuperUserRequirement.cs
+++ b/Doppler.Sap/DopplerSecurity/IsSuperUserRequirement.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Doppler.Sap.DopplerSecurity
+{
+    public class IsSuperUserRequirement : IAuthorizationRequirement
+    {
+    }
+}


### PR DESCRIPTION
add handler to validate the issuu flag of the token in the sap api, along with its tests to validate when IsSU = true / False and when it is not sent.
🤚It is necessary to add the issu flag when the token is generated in doppler-job api so that the sap api does not fail in production