### PR TITLE
feat(BusinessPartner): Change the types of the BillingStateId and StateId to string

### DIFF
--- a/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForArMapper.cs
+++ b/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForArMapper.cs
@@ -11,34 +11,6 @@ namespace Doppler.Sap.Mappers.BusinessPartner
     public class BusinessPartnerForArMapper : IBusinessPartnerMapper
     {
         private const string countryCodeSupported = "AR";
-        private readonly Dictionary<int, string> states = new Dictionary<int, string>
-        {
-            {2189,"01"}, // Buenos Aires
-            {2190,"02"}, // Catamarca
-            {2191,"16"}, // Chaco
-            {2192,"17"}, // Chubut
-            {2193,"00"}, // Ciudad Autónoma de Buenos Aires
-            {2194,"04"}, // Corrientes
-            {2195,"03"}, // Córdoba
-            {2196,"05"}, // Entre Ríos
-            {2197,"18"}, // Formosa
-            {2198,"06"}, // Jujuy
-            {2199,"21"}, // La Pampa
-            {2200,"08"}, // La Rioja
-            {2201,"07"}, // Mendoza
-            {2202,"19"}, // Misiones
-            {2203,"20"}, // Neuquén
-            {2204,"22"}, // Río Negro
-            {2205,"09"}, // Salta
-            {2206,"10"}, // San Juan
-            {2207,"11"}, // San Luis
-            {2208,"12"}, // Santa Cruz
-            {2209,"13"}, // Santa Fe
-            {2210,"14"}, // Santiago del Estero
-            {2211,"24"}, // Tierra del Fuego
-            {2212,"15"}, // Tucumán
-        };
-
 
         public bool CanMapCountry(string countryCode)
         {
@@ -121,8 +93,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
                             ZipCode = dopplerUser.BillingZip != null ? dopplerUser.BillingZip.ToUpper() : "",
                             City = dopplerUser.BillingCity != null ? dopplerUser.BillingCity.ToUpper() : "",
                             Country = dopplerUser.BillingCountryCode != null ? dopplerUser.BillingCountryCode.ToUpper() : "",
-                            State = dopplerUser.GroupCode == 115 ? dopplerUser.BillingStateId.ToString() :
-                                    (dopplerUser.BillingStateId.HasValue ? (states.TryGetValue(dopplerUser.BillingStateId.Value, out var sapBillStateId) ? sapBillStateId : "99") : "99"),
+                            State = !string.IsNullOrEmpty(dopplerUser.BillingStateId) ? dopplerUser.BillingStateId : "99",
                             AddressType = "bo_BillTo",
                                 BPCode =  cardCode,
                             RowNum = 0
@@ -134,8 +105,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
                             ZipCode = dopplerUser.BillingZip != null ? dopplerUser.BillingZip.ToUpper() : "",
                             City = dopplerUser.BillingCity != null ? dopplerUser.BillingCity.ToUpper() : "",
                             Country = dopplerUser.BillingCountryCode != null ? dopplerUser.BillingCountryCode.ToUpper() : "",
-                            State = dopplerUser.GroupCode == 115 ? dopplerUser.BillingStateId.ToString() :
-                                    (dopplerUser.BillingStateId.HasValue ? (states.TryGetValue(dopplerUser.BillingStateId.Value, out var sapShipStateId) ? sapShipStateId : "99") : "99"),
+                            State = !string.IsNullOrEmpty(dopplerUser.BillingStateId) ? dopplerUser.BillingStateId : "99",
                             AddressType = "bo_ShipTo",
                                 BPCode =  cardCode,
                             RowNum = 1

--- a/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForUsMapper.cs
+++ b/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForUsMapper.cs
@@ -10,65 +10,6 @@ namespace Doppler.Sap.Mappers.BusinessPartner
     public class BusinessPartnerForUsMapper : IBusinessPartnerMapper
     {
         private const string countryCodeSupported = "US";
-        private readonly Dictionary<int, string> states = new Dictionary<int, string>
-        {
-            {4828,"AL"}, // Alabama
-            {4829,"AK"},  // Alaska
-            {4830,"AS"}, // American Samoa
-            {4831,"AZ"}, // Arizona
-            {4832,"AR"},  // Arkansas
-            {4833,"CA"},  // California
-            {4834,"CO"},  // Colorado
-            {4835,"CT"},  // Connecticut
-            {4836,"DE"}, // Delaware
-            {4838,"FL"},  // Florida
-            {4839,"GA"}, // Georgia
-            {4840,"GU"},  // Guam
-            {4841,"HI"},  // Hawaii
-            {4842,"ID"}, // Idaho
-            {4843,"IL"}, // Illinois
-            {4844,"IN"}, // Indiana
-            {4845,"IA"},  // Iowa
-            {4846,"KS"}, // Kansas
-            {4847,"KY"}, // Kentucky
-            {4848,"LA"}, // Louisiana
-            {4849,"ME"}, // Maine
-            {4850,"MD"}, // Maryland
-            {4851,"MA"}, // Massachusetts
-            {4852,"MI"}, // Michigan
-            {4853,"AL"}, // Minnesota
-            {4854,"MN"},  // Mississippi
-            {4855,"MO"}, // Missouri
-            {4856,"MT"}, // Montana
-            {4857,"NE"},  // Nebraska
-            {4858,"NV"},  // Nevada
-            {4859,"NH"},  // New Hampshire
-            {4860,"NJ"},  // New Jersey
-            {4861,"NM"}, // New Mexico
-            {4862,"NY"},  // New York
-            {4863,"NC"}, // North Carolina
-            {4864,"ND"},  // North Dakota
-            {4865,"MP"},  // Northern Mariana Islands
-            {4866,"OH"}, // Ohio
-            {4867,"OK"}, // Oklahoma
-            {4868,"OR"}, // Oregon
-            {4869,"PA"},  // Pennsylvania
-            {4870,"PR"}, // Puerto Rico
-            {4871,"RI"}, // Rhode Island
-            {4872,"SC"}, // South Carolina
-            {4873,"SD"}, // South Dakota
-            {4874,"TN"}, // Tennessee
-            {4875,"TX"}, // Texas
-            {4876,"--"}, // United States Minor Outlying Islands
-            {4877,"UT"},  // Utah
-            {4878,"VT"}, // Vermont
-            {4879,"VI"}, // Virgin Islands, U.S.
-            {4880,"VA"},  // Virginia
-            {4881,"WA"},  // Washington
-            {4882,"WV"},  // West Virginia
-            {4883,"WI"},  // Wisconsin
-            {4884,"WY"},  // Wyoming
-        };
 
         public bool CanMapCountry(string countryCode)
         {
@@ -145,8 +86,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
                             ZipCode = dopplerUser.BillingZip != null ? dopplerUser.BillingZip.ToUpper() : "",
                             City = dopplerUser.BillingCity != null ? dopplerUser.BillingCity.ToUpper() : "",
                             Country = dopplerUser.BillingCountryCode != null ? dopplerUser.BillingCountryCode.ToUpper() : "",
-                            State = dopplerUser.GroupCode == 115 ? dopplerUser.BillingStateId.ToString() :
-                                    (states.TryGetValue(dopplerUser.BillingStateId.Value, out var sapBillStateId) ? sapBillStateId : "99"),
+                            State = !string.IsNullOrEmpty(dopplerUser.BillingStateId) ? dopplerUser.BillingStateId : "99",
                             AddressType = "bo_BillTo",
                                 BPCode =  cardCode,
                             RowNum = 0
@@ -158,8 +98,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
                             ZipCode = dopplerUser.BillingZip != null ? dopplerUser.BillingZip.ToUpper() : "",
                             City = dopplerUser.BillingCity != null ? dopplerUser.BillingCity.ToUpper() : "",
                             Country = dopplerUser.BillingCountryCode != null ? dopplerUser.BillingCountryCode.ToUpper() : "",
-                            State = dopplerUser.GroupCode == 115 ? dopplerUser.BillingStateId.ToString() :
-                                    (states.TryGetValue(dopplerUser.BillingStateId.Value, out var sapShipStateId) ? sapShipStateId : "99"),
+                            State = !string.IsNullOrEmpty(dopplerUser.BillingStateId) ? dopplerUser.BillingStateId : "99",
                             AddressType = "bo_ShipTo",
                                 BPCode =  cardCode,
                             RowNum = 1

--- a/Doppler.Sap/Models/DopplerUserDTO.cs
+++ b/Doppler.Sap/Models/DopplerUserDTO.cs
@@ -11,7 +11,6 @@ namespace Doppler.Sap.Models
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Company { get; set; }
-        public int? StateId { get; set; }
         public string CountryCode { get; set; }
         public string Address { get; set; }
         public string BillingAddress { get; set; }
@@ -30,7 +29,7 @@ namespace Doppler.Sap.Models
         public bool? IsInbound { get; set; }
         public string BillingCity { get; set; }
         public string BillingCountryCode { get; set; }
-        public int? BillingStateId { get; set; }
+        public string BillingStateId { get; set; }
         public int? PlanType { get; set; }
         public int PaymentMethod { get; set; }
         public string FederalTaxType { get; set; }


### PR DESCRIPTION
Change the types of the BillingStateId and StateId to string

**Changes:**

- Updated the type of the BillingStateId and StateId properties to string.

- Remove the dictionary to map the stateId Between Doppler and SAP. It functionallity will be add in Doppler's task: **DAT-209**.

**Task:** [DAT-210](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-210)
