### PR TITLE
feat: Add logic to calculate the GroupCode depending if use Ar or Us

### DIFF
--- a/Doppler.Sap.Test/Mappers/BusinessPartnerForArMapperTest.cs
+++ b/Doppler.Sap.Test/Mappers/BusinessPartnerForArMapperTest.cs
@@ -1,0 +1,152 @@
+using Doppler.Sap.Mappers.BusinessPartner;
+using Doppler.Sap.Models;
+using Xunit;
+
+namespace Doppler.Sap.Test.Mappers
+{
+    public class BusinessPartnerForArMapperTest
+    {
+        [Fact]
+        public void BusinessPartnerForArMapper_ShouldBeSetGroupCodeAltoVolumen_WhenIsDopplerAndPlanTypeEqual2()
+        {
+            var groupCode = 104;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 2,
+                IsClientManager = false,
+                IsFromRelay = false,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com"
+            };
+
+            BusinessPartnerForArMapper mapper = new BusinessPartnerForArMapper();
+
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+
+        [Fact]
+        public void BusinessPartnerForArMapper_ShouldBeSetGroupCodePrepago_WhenIsDopplerAndPlanTypeEqual3()
+        {
+            var groupCode = 105;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 3,
+                IsClientManager = false,
+                IsFromRelay = false,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com"
+            };
+
+            BusinessPartnerForArMapper mapper = new BusinessPartnerForArMapper();
+
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+
+        [Fact]
+        public void BusinessPartnerForArMapper_ShouldBeSetGroupCodeContactos_WhenIsDopplerAndPlanTypeEqual4()
+        {
+            var groupCode = 100;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 4,
+                IsClientManager = false,
+                IsFromRelay = false,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com"
+            };
+
+            BusinessPartnerForArMapper mapper = new BusinessPartnerForArMapper();
+
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+
+        [Fact]
+        public void BusinessPartnerForArMapper_ShouldBeSetGroupCodeClientManager_WhenIsClientManagerAndClientManagerTypeEqual1()
+        {
+            var groupCode = 106;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 1,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com"
+            };
+
+            BusinessPartnerForArMapper mapper = new BusinessPartnerForArMapper();
+
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+
+        [Fact]
+        public void BusinessPartnerForArMapper_ShouldBeSetGroupCodeClientManagerResel_WhenIsClientManagerAndClientManagerTypeEqual2()
+        {
+            var groupCode = 114;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 2,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com"
+            };
+
+            BusinessPartnerForArMapper mapper = new BusinessPartnerForArMapper();
+
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+
+        [Fact]
+        public void BusinessPartnerForArMapper_ShouldBeSetGroupCodeRelay_WhenIsRelay()
+        {
+            var groupCode = 115;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 5,
+                IsFromRelay = true,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com"
+            };
+
+            BusinessPartnerForArMapper mapper = new BusinessPartnerForArMapper();
+
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+    }
+}

--- a/Doppler.Sap.Test/Mappers/BusinessPartnerForUsMapperTest.cs
+++ b/Doppler.Sap.Test/Mappers/BusinessPartnerForUsMapperTest.cs
@@ -1,0 +1,152 @@
+using Doppler.Sap.Mappers.BusinessPartner;
+using Doppler.Sap.Models;
+using Xunit;
+
+namespace Doppler.Sap.Test.Mappers
+{
+    public class BusinessPartnerForUsMapperTest
+    {
+        [Fact]
+        public void BusinessPartnerForUsMapper_ShouldBeSetGroupCodeAltoVolumen_WhenIsDopplerAndPlanTypeEqual2()
+        {
+            var groupCode = 103;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 2,
+                IsClientManager = false,
+                IsFromRelay = false,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingSystemId = 2
+            };
+
+            var mapper = new BusinessPartnerForUsMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+
+        [Fact]
+        public void BusinessPartnerForUsMapper_ShouldBeSetGroupCodePrepago_WhenIsDopplerAndPlanTypeEqual3()
+        {
+            var groupCode = 102;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 3,
+                IsClientManager = false,
+                IsFromRelay = false,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingSystemId = 2
+            };
+
+            var mapper = new BusinessPartnerForUsMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+
+        [Fact]
+        public void BusinessPartnerForUsMapper_ShouldBeSetGroupCodeContactos_WhenIsDopplerAndPlanTypeEqual4()
+        {
+            var groupCode = 100;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 4,
+                IsClientManager = false,
+                IsFromRelay = false,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingSystemId = 2
+            };
+
+            var mapper = new BusinessPartnerForUsMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+
+        [Fact]
+        public void BusinessPartnerForUsMapper_ShouldBeSetGroupCodeClientManager_WhenIsClientManagerAndClientManagerTypeEqual1()
+        {
+            var groupCode = 104;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 1,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingSystemId = 2
+            };
+
+            var mapper = new BusinessPartnerForUsMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+
+        [Fact]
+        public void BusinessPartnerForUsMapper_ShouldBeSetGroupCodeClientManagerResel_WhenIsClientManagerAndClientManagerTypeEqual2()
+        {
+            var groupCode = 105;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 2,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingSystemId = 2
+            };
+
+            var mapper = new BusinessPartnerForUsMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+
+        [Fact]
+        public void BusinessPartnerForUsMapper_ShouldBeSetGroupCodeRelay_WhenIsFromRelay()
+        {
+            var groupCode = 106;
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 5,
+                IsFromRelay = true,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingSystemId = 2
+            };
+
+            var mapper = new BusinessPartnerForUsMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
+        }
+    }
+}

--- a/Doppler.Sap/Factory/SapTaskHandler.cs
+++ b/Doppler.Sap/Factory/SapTaskHandler.cs
@@ -146,7 +146,7 @@ namespace Doppler.Sap.Factory
         {
             var existentBusinessPartner = await TryGetBusinessPartner(task.DopplerUser.Id, task.DopplerUser.FederalTaxID, task.DopplerUser.PlanType.Value);
 
-            var fatherCard = task.DopplerUser.GroupCode == 115 ?
+            var fatherCard = task.DopplerUser.IsFromRelay ?
                     $"CR{task.DopplerUser.Id:0000000000000}" :
                     (task.DopplerUser.IsClientManager ?
                     $"CD{int.Parse("400" + task.DopplerUser.Id.ToString()):0000000000000}" :

--- a/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForArMapper.cs
+++ b/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForArMapper.cs
@@ -4,13 +4,44 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
-using System.Threading.Tasks;
 
 namespace Doppler.Sap.Mappers.BusinessPartner
 {
-    public class BusinessPartnerForArMapper : IBusinessPartnerMapper
+    public class BusinessPartnerForArMapper : BusinessPartnerMapper, IBusinessPartnerMapper
     {
         private const string countryCodeSupported = "AR";
+        private readonly Dictionary<int, int> dopplerGroupCodes = new Dictionary<int, int>
+        {
+            {2,104}, //alto volumen
+            {3,105}, //prepago
+            {4,100}  //contactos
+        };
+
+        private readonly Dictionary<int, int> clientManagerGroupCodes = new Dictionary<int, int>
+        {
+            {1,106}, //Client Manager
+            {2,114}, //Client Manager Resel
+        };
+
+        private readonly Dictionary<int, int> relayGroupCodes = new Dictionary<int, int>
+        {
+            {5,115}, //Relay
+        };
+
+        /// <summary>
+        /// Key: PlanType; Value: GroupCode
+        /// </summary>
+        protected override Dictionary<int, int> DopplerGroupCodes { get => dopplerGroupCodes; }
+
+        /// <summary>
+        /// Key: ClientManagerType; Value: GroupCode
+        /// </summary>
+        protected override Dictionary<int, int> ClientManagerGroupCodes { get => clientManagerGroupCodes; }
+
+        /// <summary>
+        /// Key: PlanType; Value: GroupCode
+        /// </summary>
+        protected override Dictionary<int, int> RelayGroupCodes { get => relayGroupCodes; }
 
         public bool CanMapCountry(string countryCode)
         {
@@ -31,7 +62,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
             {
                 CardCode = cardCode,
                 CardName = $"{dopplerUser.FirstName} {dopplerUser.LastName}".ToUpper(),
-                GroupCode = dopplerUser.GroupCode,
+                GroupCode = MapGroupCode(dopplerUser),
                 PayTermsGrpCode = dopplerUser.PaymentMethod == (int)PaymentMethodEnum.MP ? (int)PayTermsGroupEnum.MP : (int)PayTermsGroupEnum.DEFAULT,
                 ContactPerson = new MailAddress((dopplerUser.BillingEmails != null && dopplerUser.BillingEmails[0] != String.Empty) ?
                 dopplerUser.BillingEmails[0].ToLower() :

--- a/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForUsMapper.cs
+++ b/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForUsMapper.cs
@@ -3,13 +3,44 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
-using System.Threading.Tasks;
 
 namespace Doppler.Sap.Mappers.BusinessPartner
 {
-    public class BusinessPartnerForUsMapper : IBusinessPartnerMapper
+    public class BusinessPartnerForUsMapper : BusinessPartnerMapper, IBusinessPartnerMapper
     {
         private const string countryCodeSupported = "US";
+        private readonly Dictionary<int, int> dopplerGroupCodes = new Dictionary<int, int>
+        {
+            {2,103}, //alto volumen
+            {3,102}, //prepago
+            {4,100}  //contactos
+        };
+
+        private readonly Dictionary<int, int> clientManagerGroupCodes = new Dictionary<int, int>
+        {
+            {1,104}, //Client Manager
+            {2,105}, //Client Manager Resel
+        };
+
+        private readonly Dictionary<int, int> relayGroupCodes = new Dictionary<int, int>
+        {
+            {5,106}, //Relay
+        };
+
+        /// <summary>
+        /// Key: PlanType; Value: GroupCode
+        /// </summary>
+        protected override Dictionary<int, int> DopplerGroupCodes { get => dopplerGroupCodes; }
+
+        /// <summary>
+        /// Key: ClientManagerType; Value: GroupCode
+        /// </summary>
+        protected override Dictionary<int, int> ClientManagerGroupCodes { get => clientManagerGroupCodes; }
+
+        /// <summary>
+        /// Key: PlanType; Value: GroupCode
+        /// </summary>
+        protected override Dictionary<int, int> RelayGroupCodes { get => relayGroupCodes; }
 
         public bool CanMapCountry(string countryCode)
         {
@@ -30,7 +61,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
             {
                 CardCode = cardCode,
                 CardName = $"{dopplerUser.FirstName} {dopplerUser.LastName}".ToUpper(),
-                GroupCode = dopplerUser.GroupCode,
+                GroupCode = MapGroupCode(dopplerUser),
                 PayTermsGrpCode = -1,
                 ContactPerson = new MailAddress((dopplerUser.BillingEmails != null && dopplerUser.BillingEmails[0] != String.Empty) ?
                 dopplerUser.BillingEmails[0].ToLower() :

--- a/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerMapper.cs
+++ b/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerMapper.cs
@@ -1,0 +1,34 @@
+using Doppler.Sap.Models;
+using System.Collections.Generic;
+
+namespace Doppler.Sap.Mappers.BusinessPartner
+{
+    public abstract class BusinessPartnerMapper
+    {
+        /// <summary>
+        /// Key: PlanType; Value: GroupCode
+        /// </summary>
+        protected abstract Dictionary<int, int> DopplerGroupCodes { get; }
+
+        /// <summary>
+        /// Key: ClientManagerType; Value: GroupCode
+        /// </summary>
+        protected abstract Dictionary<int, int> ClientManagerGroupCodes { get; }
+
+        /// <summary>
+        /// Key: PlanType; Value: GroupCode
+        /// </summary>
+        protected abstract Dictionary<int, int> RelayGroupCodes { get; }
+
+        protected int MapGroupCode(DopplerUserDto dopplerUser)
+        {
+            var groupCode = (!dopplerUser.IsClientManager && !dopplerUser.IsFromRelay) ?
+                            (dopplerUser.PlanType.HasValue ? (DopplerGroupCodes.TryGetValue(dopplerUser.PlanType.Value, out var dopplerGroupCode) ? dopplerGroupCode : 0) : 0) :
+                            (dopplerUser.IsClientManager) ?
+                            ClientManagerGroupCodes.TryGetValue(dopplerUser.ClientManagerType, out var clientManagerGroupCode) ? clientManagerGroupCode : 0 :
+                            (dopplerUser.PlanType.HasValue ? (RelayGroupCodes.TryGetValue(dopplerUser.PlanType.Value, out var relayGroupCode) ? relayGroupCode : 0) : 0);
+
+            return groupCode;
+        }
+    }
+}

--- a/Doppler.Sap/Models/DopplerUserDTO.cs
+++ b/Doppler.Sap/Models/DopplerUserDTO.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace Doppler.Sap.Models
 {
     public class DopplerUserDto
@@ -23,7 +18,9 @@ namespace Doppler.Sap.Models
         public int GroupCode { get; set; }
         public SapProperties SAPProperties { get; set; }
         public string[] BillingEmails { get; set; }
+        //TODO: Both properties will be remove to use a new Product property.
         public bool IsClientManager { get; set; }
+        public bool IsFromRelay { get; set; }
         public bool Cancelated { get; set; }
         public bool Blocked { get; set; }
         public bool? IsInbound { get; set; }
@@ -35,5 +32,6 @@ namespace Doppler.Sap.Models
         public string FederalTaxType { get; set; }
         public string FederalTaxID { get; set; }
         public int BillingSystemId { get; set; }
+        public int ClientManagerType { get; set; }
     }
 }


### PR DESCRIPTION
Added logic to calculate the GroupCode depending if the SAP System is AR or US.

We need it implementation because in the databases the group code are different. For example:

AR:
![image](https://user-images.githubusercontent.com/70591946/100263599-77ce3000-2f2c-11eb-9698-c09457b17094.png)

US:
![image](https://user-images.githubusercontent.com/70591946/100263706-99c7b280-2f2c-11eb-83d1-37dd5e48c4a3.png)


**Changes:**

- Added logic to calculate the GroupCode.

- Added new unit tests to verify the different scenarios of the GroupCode.


**Task:** [DAT-205](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-205)

