### PR TITLE
Fix State of business partner mapper

### DIFF
--- a/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForUsMapper.cs
+++ b/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForUsMapper.cs
@@ -117,7 +117,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
                             ZipCode = dopplerUser.BillingZip != null ? dopplerUser.BillingZip.ToUpper() : "",
                             City = dopplerUser.BillingCity != null ? dopplerUser.BillingCity.ToUpper() : "",
                             Country = dopplerUser.BillingCountryCode != null ? dopplerUser.BillingCountryCode.ToUpper() : "",
-                            State = !string.IsNullOrEmpty(dopplerUser.BillingStateId) && dopplerUser.BillingCountryCode == "US" ? dopplerUser.BillingStateId : null,
+                            State = !string.IsNullOrEmpty(dopplerUser.BillingStateId) && dopplerUser.BillingCountryCode == "US" ? dopplerUser.BillingStateId : string.Empty,
                             AddressType = "bo_BillTo",
                                 BPCode =  cardCode,
                             RowNum = 0
@@ -129,7 +129,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
                             ZipCode = dopplerUser.BillingZip != null ? dopplerUser.BillingZip.ToUpper() : "",
                             City = dopplerUser.BillingCity != null ? dopplerUser.BillingCity.ToUpper() : "",
                             Country = dopplerUser.BillingCountryCode != null ? dopplerUser.BillingCountryCode.ToUpper() : "",
-                            State = !string.IsNullOrEmpty(dopplerUser.BillingStateId) && dopplerUser.BillingCountryCode == "US" ? dopplerUser.BillingStateId : null,
+                            State = !string.IsNullOrEmpty(dopplerUser.BillingStateId) && dopplerUser.BillingCountryCode == "US" ? dopplerUser.BillingStateId : string.Empty,
                             AddressType = "bo_ShipTo",
                                 BPCode =  cardCode,
                             RowNum = 1


### PR DESCRIPTION
# Background
We need to set `string.Empty` the state because Sap System returns an error if the state is null

![image](https://user-images.githubusercontent.com/6796523/100647901-ef320400-331e-11eb-91ca-a252f4595c2b.png)
