### PR TITLE
feat: Use Argentina timezone for the dates in the invoice and payment

### DIFF
--- a/Doppler.Sap.Test/BillingRequestHandlerTest.cs
+++ b/Doppler.Sap.Test/BillingRequestHandlerTest.cs
@@ -10,7 +10,6 @@ using Doppler.Sap.Models;
 using Doppler.Sap.Services;
 using Doppler.Sap.Utils;
 using Doppler.Sap.Validations.Billing;
-using Doppler.Sap.Validations.BusinessPartner;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -30,17 +29,23 @@ namespace Doppler.Sap.Test
                 new BillingForUsValidation(Mock.Of<ILogger<BillingForUsValidation>>())
             };
 
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+
             var dateTimeProviderMock = new Mock<IDateTimeProvider>();
             dateTimeProviderMock.Setup(x => x.UtcNow)
                 .Returns(new DateTime(2019, 09, 25));
 
             var billingMappers = new List<IBillingMapper>
             {
-                new BillingForArMapper(Mock.Of<ISapBillingItemsService>()),
-                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object)
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations)
             };
 
-            var sapConfigMock = new Mock<IOptions<SapConfig>>();
             sapConfigMock.Setup(x => x.Value)
                 .Returns(new SapConfig
                 {
@@ -139,17 +144,21 @@ namespace Doppler.Sap.Test
                 new BillingForUsValidation(Mock.Of<ILogger<BillingForUsValidation>>())
             };
 
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
             var dateTimeProviderMock = new Mock<IDateTimeProvider>();
             dateTimeProviderMock.Setup(x => x.UtcNow)
                 .Returns(new DateTime(2019, 09, 25));
 
             var billingMappers = new List<IBillingMapper>
             {
-                new BillingForArMapper(Mock.Of<ISapBillingItemsService>()),
-                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object)
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations)
             };
 
-            var sapConfigMock = new Mock<IOptions<SapConfig>>();
             var httpClientFactoryMock = new Mock<IHttpClientFactory>();
             var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
             httpMessageHandlerMock.Protected()
@@ -200,17 +209,20 @@ namespace Doppler.Sap.Test
                 new BillingForUsValidation(Mock.Of<ILogger<BillingForUsValidation>>())
             };
 
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
             var dateTimeProviderMock = new Mock<IDateTimeProvider>();
             dateTimeProviderMock.Setup(x => x.UtcNow)
                 .Returns(new DateTime(2019, 09, 25));
 
             var billingMappers = new List<IBillingMapper>
             {
-                new BillingForArMapper(Mock.Of<ISapBillingItemsService>()),
-                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object)
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations)
             };
-
-            var sapConfigMock = new Mock<IOptions<SapConfig>>();
 
             var httpClientFactoryMock = new Mock<IHttpClientFactory>();
             var httpMessageHandlerMock = new Mock<HttpMessageHandler>();

--- a/Doppler.Sap.Test/BillingServiceTest.cs
+++ b/Doppler.Sap.Test/BillingServiceTest.cs
@@ -7,6 +7,7 @@ using Doppler.Sap.Services;
 using Doppler.Sap.Utils;
 using Doppler.Sap.Validations.Billing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -17,6 +18,11 @@ namespace Doppler.Sap.Test
         [Fact]
         public async Task BillingService_ShouldNotBeAddTaskInQueue_WhenCurrencyRateListIsEmpty()
         {
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
             var queuingServiceMock = new Mock<IQueuingService>();
             var dateTimeProviderMock = new Mock<IDateTimeProvider>();
             dateTimeProviderMock.Setup(x => x.UtcNow)
@@ -24,8 +30,8 @@ namespace Doppler.Sap.Test
 
             var billingMappers = new List<IBillingMapper>
             {
-                new BillingForArMapper(null),
-                new BillingForUsMapper(null, dateTimeProviderMock.Object)
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations)
             };
 
             var billingService = new BillingService(queuingServiceMock.Object,
@@ -45,6 +51,11 @@ namespace Doppler.Sap.Test
         [Fact]
         public async Task BillingService_ShouldBeAddTaskInQueue_WhenCurrencyRateListHasOneValidElement()
         {
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
             var queuingServiceMock = new Mock<IQueuingService>();
             var dateTimeProviderMock = new Mock<IDateTimeProvider>();
             dateTimeProviderMock.Setup(x => x.UtcNow)
@@ -52,8 +63,8 @@ namespace Doppler.Sap.Test
 
             var billingMappers = new List<IBillingMapper>
             {
-                new BillingForArMapper(null),
-                new BillingForUsMapper(null, dateTimeProviderMock.Object)
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations)
             };
 
             var billingService = new BillingService(queuingServiceMock.Object,
@@ -82,14 +93,19 @@ namespace Doppler.Sap.Test
         [Fact]
         public async Task BillingService_ShouldBeAddThreeTasksInQueue_WhenListHasOneValidElementWithFridayDay()
         {
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
             var dateTimeProviderMock = new Mock<IDateTimeProvider>();
             dateTimeProviderMock.Setup(x => x.UtcNow)
                 .Returns(new DateTime(2020, 12, 04));
 
             var billingMappers = new List<IBillingMapper>
             {
-                new BillingForArMapper(null),
-                new BillingForUsMapper(null, dateTimeProviderMock.Object)
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations)
             };
 
             var queuingServiceMock = new Mock<IQueuingService>();
@@ -136,6 +152,11 @@ namespace Doppler.Sap.Test
                 new BillingForUsValidation(Mock.Of<ILogger<BillingForUsValidation>>())
             };
 
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
             var sapBillingItemsServiceMock = new Mock<ISapBillingItemsService>();
             sapBillingItemsServiceMock.Setup(x => x.GetItemCode(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>())).Returns(itemCode);
             sapBillingItemsServiceMock.Setup(x => x.GetItems(It.IsAny<int>())).Returns(items);
@@ -146,8 +167,8 @@ namespace Doppler.Sap.Test
 
             var billingMappers = new List<IBillingMapper>
             {
-                new BillingForArMapper(sapBillingItemsServiceMock.Object),
-                new BillingForUsMapper(sapBillingItemsServiceMock.Object, dateTimeProviderMock.Object)
+                new BillingForArMapper(sapBillingItemsServiceMock.Object, dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(sapBillingItemsServiceMock.Object, dateTimeProviderMock.Object, timeZoneConfigurations)
             };
 
             var queuingServiceMock = new Mock<IQueuingService>();
@@ -176,14 +197,19 @@ namespace Doppler.Sap.Test
         [Fact]
         public async Task BillingService_ShouldBeAddOneTaskInQueue_WhenBillingRequestListHasOneInvalidElement()
         {
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
             var dateTimeProviderMock = new Mock<IDateTimeProvider>();
             dateTimeProviderMock.Setup(x => x.UtcNow)
                 .Returns(new DateTime(2019, 09, 25));
 
             var billingMappers = new List<IBillingMapper>
             {
-                new BillingForArMapper(null),
-                new BillingForUsMapper(null, dateTimeProviderMock.Object)
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations)
             };
 
             var slackServiceMock = new Mock<ISlackService>();
@@ -216,14 +242,19 @@ namespace Doppler.Sap.Test
         [Fact]
         public async Task BillingService_ShouldBeAddOneTaskInQueue_WhenBillingRequestListHasOneInvalidCountryCodeElement()
         {
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
             var dateTimeProviderMock = new Mock<IDateTimeProvider>();
             dateTimeProviderMock.Setup(x => x.UtcNow)
                 .Returns(new DateTime(2019, 09, 25));
 
             var billingMappers = new List<IBillingMapper>
             {
-                new BillingForArMapper(null),
-                new BillingForUsMapper(null, dateTimeProviderMock.Object)
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations)
             };
 
             var slackServiceMock = new Mock<ISlackService>();

--- a/Doppler.Sap.Test/Utils/DateTimeProviderTest.cs
+++ b/Doppler.Sap.Test/Utils/DateTimeProviderTest.cs
@@ -1,0 +1,117 @@
+using Doppler.Sap.Utils;
+using System;
+using Xunit;
+
+namespace Doppler.Sap.Test.Utils
+{
+    public class DateTimeProviderTest
+    {
+        [Fact]
+        public void DateTimeProvider_ShouldBeReturnDateInArgentinaTimezone_WhenTimeZoneIsNotNull()
+        {
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+            var dateTimeProvider = new DateTimeProvider();
+            var utcDate = dateTimeProvider.UtcNow;
+            var cstZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneConfigurations.InvoicesTimeZone);
+
+            var expectedDate = utcDate.AddMinutes(cstZone.BaseUtcOffset.TotalMinutes);
+            var result = dateTimeProvider.GetDateByTimezoneId(utcDate, timeZoneConfigurations.InvoicesTimeZone);
+
+            Assert.Equal(expectedDate, result);
+        }
+
+        [Fact]
+        public void DateTimeProvider_ShouldBeReturnPreviousDateInArgentinaTimezone_WhenTimeZoneIsNotNullAndTheDateAfter0clock()
+        {
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+            var dateTimeProvider = new DateTimeProvider();
+            var utcDate = new DateTime(2020, 12, 13, 0, 10, 0);
+            var expectedDate = new DateTime(2020, 12, 12, 0, 10, 0);
+
+            var result = dateTimeProvider.GetDateByTimezoneId(utcDate, timeZoneConfigurations.InvoicesTimeZone);
+
+            Assert.Equal(expectedDate.Date, result.Date);
+        }
+
+        [Fact]
+        public void DateTimeProvider_ShouldBeReturnDate_WhenTimeZoneIsNull()
+        {
+            var timezoneId = "";
+            var dateTimeProvider = new DateTimeProvider();
+            var utcDate = dateTimeProvider.UtcNow;
+
+            var result = dateTimeProvider.GetDateByTimezoneId(utcDate, timezoneId);
+
+            Assert.Equal(utcDate, result);
+        }
+
+        [Fact]
+        public void DateTimeProvider_PredefinedValues_ShouldBeReturnDateInArgentinaTimezone_WhenTimeZoneIsNotNull()
+        {
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+            var dateTimeProvider = new DateTimeProvider();
+            var utcDate = new DateTime(2020, 12, 14, 14, 0, 0, DateTimeKind.Utc);
+            var expectedDate = new DateTime(2020, 12, 14, 11, 0, 0);
+
+            var result = dateTimeProvider.GetDateByTimezoneId(utcDate, timeZoneConfigurations.InvoicesTimeZone);
+
+            Assert.Equal(expectedDate, result);
+        }
+
+        [Fact]
+        public void DateTimeProvider_PredefinedValues_ShouldBeReturnPreviousDateInArgentinaTimezone_WhenTimeZoneIsNotNullAndTheDateAfter0clockAndKingUtc()
+        {
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+            var dateTimeProvider = new DateTimeProvider();
+            var date = new DateTime(2020, 12, 13, 0, 10, 0, DateTimeKind.Utc);
+            var expectedDate = new DateTime(2020, 12, 12, 21, 10, 0);
+
+            var result = dateTimeProvider.GetDateByTimezoneId(date, timeZoneConfigurations.InvoicesTimeZone);
+
+            Assert.Equal(expectedDate, result);
+        }
+
+        [Fact]
+        public void DateTimeProvider_PredefinedValues_ShouldBeReturnPreviousDateInArgentinaTimezone_WhenTimeZoneIsNotNullAndTheDateAfter0clockAndKingUnspecified()
+        {
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+            var dateTimeProvider = new DateTimeProvider();
+            var date = new DateTime(2020, 12, 13, 0, 0, 0, DateTimeKind.Unspecified);
+            var expectedDate = new DateTime(2020, 12, 12, 21, 0, 0);
+
+            var result = dateTimeProvider.GetDateByTimezoneId(date, timeZoneConfigurations.InvoicesTimeZone);
+
+            Assert.Equal(expectedDate, result);
+        }
+
+        [Fact]
+        public void DateTimeProvider_PredefinedValues_ShouldBeReturnAnArgumentException_WhenTheKingLocal()
+        {
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+            var dateTimeProvider = new DateTimeProvider();
+            var date = new DateTime(2020, 12, 13, 0, 0, 0, DateTimeKind.Local);
+
+            var ex = Assert.Throws<ArgumentException>(() => dateTimeProvider.GetDateByTimezoneId(date, timeZoneConfigurations.InvoicesTimeZone));
+            var isExpectedMessage = ex.Message.Contains("The conversion could not be completed because the supplied DateTime did not have the Kind property set correctly");
+            Assert.True(isExpectedMessage);
+        }
+    }
+}

--- a/Doppler.Sap/Doppler.Sap.csproj
+++ b/Doppler.Sap/Doppler.Sap.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.6.3" />
+    <PackageReference Include="TimeZoneConverter" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Doppler.Sap/Mappers/Billing/BillingForArMapper.cs
+++ b/Doppler.Sap/Mappers/Billing/BillingForArMapper.cs
@@ -1,5 +1,6 @@
 using Doppler.Sap.Models;
 using Doppler.Sap.Services;
+using Doppler.Sap.Utils;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -16,10 +17,14 @@ namespace Doppler.Sap.Mappers.Billing
         private const string _costingCode4 = "NOAPLI4";
 
         private readonly ISapBillingItemsService _sapBillingItemsService;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly TimeZoneConfigurations _timezoneConfig;
 
-        public BillingForArMapper(ISapBillingItemsService sapBillingItemsService)
+        public BillingForArMapper(ISapBillingItemsService sapBillingItemsService, IDateTimeProvider dateTimeProvider, TimeZoneConfigurations timezoneConfig)
         {
             _sapBillingItemsService = sapBillingItemsService;
+            _dateTimeProvider = dateTimeProvider;
+            _timezoneConfig = timezoneConfig;
         }
 
         public bool CanMapSapSystem(string sapSystem)
@@ -33,7 +38,10 @@ namespace Doppler.Sap.Mappers.Billing
             {
                 NumAtCard = billingRequest.PurchaseOrder ?? "",
                 U_DPL_RECURRING_SERV = billingRequest.IsPlanUpgrade ? "N" : "Y",
-                DocumentLines = new List<SapDocumentLineModel>()
+                DocumentLines = new List<SapDocumentLineModel>(),
+                DocDate = _dateTimeProvider.GetDateByTimezoneId(_dateTimeProvider.UtcNow, _timezoneConfig.InvoicesTimeZone).ToString("yyyy-MM-dd"),
+                DocDueDate = _dateTimeProvider.GetDateByTimezoneId(_dateTimeProvider.UtcNow, _timezoneConfig.InvoicesTimeZone).ToString("yyyy-MM-dd"),
+                TaxDate = _dateTimeProvider.GetDateByTimezoneId(_dateTimeProvider.UtcNow, _timezoneConfig.InvoicesTimeZone).ToString("yyyy-MM-dd")
             };
             var currencyCode = Dictionary.CurrencyDictionary.TryGetValue(billingRequest.Currency, out var code) ? code : "";
 

--- a/Doppler.Sap/Models/SapConfig.cs
+++ b/Doppler.Sap/Models/SapConfig.cs
@@ -9,5 +9,6 @@ namespace Doppler.Sap.Models
         public int SessionTimeoutPadding { get; set; }
         public bool UseDummyData { get; set; }
         public Dictionary<string, SapServiceConfig> SapServiceConfigsBySystem { get; set; }
+        public string TimeZone { get; set; }
     }
 }

--- a/Doppler.Sap/Models/SapSaleOrderModel.cs
+++ b/Doppler.Sap/Models/SapSaleOrderModel.cs
@@ -6,9 +6,9 @@ namespace Doppler.Sap.Models
     public class SapSaleOrderModel
     {
         public string CardCode { get; set; }
-        public string DocDate { get; set; } = DateTime.UtcNow.ToString("yyyy-MM-dd");
-        public string DocDueDate { get; set; } = DateTime.UtcNow.ToString("yyyy-MM-dd");
-        public string TaxDate { get; set; } = DateTime.UtcNow.ToString("yyyy-MM-dd");
+        public string DocDate { get; set; }
+        public string DocDueDate { get; set; }
+        public string TaxDate { get; set; }
         public string NumAtCard { get; set; }
         public string U_DPL_RECURRING_SERV { get; set; }
         public List<SapDocumentLineModel> DocumentLines { get; set; }

--- a/Doppler.Sap/Startup.cs
+++ b/Doppler.Sap/Startup.cs
@@ -80,6 +80,13 @@ namespace Doppler.Sap
                     UseCookies = false
                 });
             services.AddSapServices();
+
+            var timezoneConfig = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem(Configuration["SapConfig:InvoicesTimeZone"])
+            };
+            services.AddSingleton(timezoneConfig);
+
             services.AddSingleton<IQueuingService, QueuingService>();
             services.AddTransient<ISapService, SapService>();
 

--- a/Doppler.Sap/Utils/DateTimeProvider.cs
+++ b/Doppler.Sap/Utils/DateTimeProvider.cs
@@ -1,9 +1,21 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace Doppler.Sap.Utils
 {
     public class DateTimeProvider : IDateTimeProvider
     {
         public DateTime UtcNow => DateTime.UtcNow;
+
+        public DateTime GetDateByTimezoneId(DateTime date, string timezoneId)
+        {
+            if (!string.IsNullOrEmpty(timezoneId))
+            {
+                var cstZone = TimeZoneInfo.FindSystemTimeZoneById(timezoneId);
+                return TimeZoneInfo.ConvertTimeFromUtc(date, cstZone);
+            }
+
+            return date;
+        }
     }
 }

--- a/Doppler.Sap/Utils/IDateTimeProvider.cs
+++ b/Doppler.Sap/Utils/IDateTimeProvider.cs
@@ -5,5 +5,7 @@ namespace Doppler.Sap.Utils
     public interface IDateTimeProvider
     {
         DateTime UtcNow { get; }
+
+        DateTime GetDateByTimezoneId(DateTime date, string timezoneId);
     }
 }

--- a/Doppler.Sap/Utils/TimeZoneConfigurations.cs
+++ b/Doppler.Sap/Utils/TimeZoneConfigurations.cs
@@ -1,0 +1,7 @@
+namespace Doppler.Sap.Utils
+{
+    public class TimeZoneConfigurations
+    {
+        public string InvoicesTimeZone { get; set; }
+    }
+}

--- a/Doppler.Sap/Utils/TimeZoneHelper.cs
+++ b/Doppler.Sap/Utils/TimeZoneHelper.cs
@@ -1,0 +1,14 @@
+using System.Runtime.InteropServices;
+using TimeZoneConverter;
+
+namespace Doppler.Sap.Utils
+{
+    public static class TimeZoneHelper
+    {
+        public static string GetTimeZoneByOperativeSystem(string timeZone)
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? timeZone
+                : TZConvert.WindowsToIana(timeZone);
+        }
+    }
+}

--- a/Doppler.Sap/appsettings.json
+++ b/Doppler.Sap/appsettings.json
@@ -44,6 +44,7 @@
     },
     "SlackAlertUrl": "[SECRET_KEY]",
     "MaxAmountAllowedAccounts": 10,
-    "SessionTimeoutPadding": 2
+    "SessionTimeoutPadding": 2,
+    "InvoicesTimeZone": "Argentina Standard Time"
   }
 }


### PR DESCRIPTION
Convert the UtcNow date to Argentina timezone for the dates in the invoice and payment.

**Changes:**

- Created a method in the class: ```DateTimeProvider``` to convert the UtcNow date to Argentina timezone.

- Added new UTs.
