### PR TITLE
feat: Add validation about first name and last name when create or update some business partner

### DIFF
--- a/Doppler.Sap.Test/BusinessPartnerServiceTest.cs
+++ b/Doppler.Sap.Test/BusinessPartnerServiceTest.cs
@@ -64,6 +64,8 @@ namespace Doppler.Sap.Test
             var dopplerUser = new DopplerUserDto
             {
                 Id = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
                 FederalTaxID = "27111111115",
                 PlanType = 1,
                 BillingSystemId = 2
@@ -122,6 +124,103 @@ namespace Doppler.Sap.Test
         }
 
         [Fact]
+        public void BusinessPartnerService_ShouldBeThrowsValidationException_WhenDopplerUserFirstNameAndLastNameAreNotValidAndSapAr()
+        {
+            var businessPartnerValidations = new List<IBusinessPartnerValidation>
+            {
+                new BusinessPartnerForArValidation(Mock.Of<ILogger<BusinessPartnerForArValidation>>()),
+                new BusinessPartnerForUsValidation(Mock.Of<ILogger<BusinessPartnerForUsValidation>>())
+            };
+
+            var loggerMock = new Mock<ILogger<BusinessPartnerService>>();
+            var queuingServiceMock = new Mock<IQueuingService>();
+
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            sapConfigMock.Setup(x => x.Value)
+                .Returns(new SapConfig
+                {
+                    SapServiceConfigsBySystem = new Dictionary<string, SapServiceConfig>
+                    {
+                        { "AR", new SapServiceConfig {
+                            CompanyDB = "CompanyDb",
+                            Password = "password",
+                            UserName = "Name",
+                            BaseServerUrl = "http://123.123.123/",
+                            BusinessPartnerConfig = new BusinessPartnerConfig
+                            {
+                                Endpoint = "BusinessPartners"
+                            }
+                        }
+                        }
+                    }
+                });
+
+            var businessPartnerService = new BusinessPartnerService(queuingServiceMock.Object, loggerMock.Object, sapConfigMock.Object, businessPartnerValidations);
+
+            var dopplerUser = new DopplerUserDto
+            {
+                Id = 1,
+                FirstName = "",
+                LastName = "",
+                FederalTaxID = "123",
+                PlanType = 1,
+                BillingCountryCode = "AR",
+                BillingSystemId = 9
+            };
+
+            var ex = Assert.ThrowsAsync<ValidationException>(() => businessPartnerService.CreateOrUpdateBusinessPartner(dopplerUser));
+            Assert.Equal("Invalid first name or last name.", ex.Result.Message);
+        }
+
+        [Fact]
+        public void BusinessPartnerService_ShouldBeThrowsValidationException_WhenDopplerUserFirstNameAndLastNameAreNotValidAndSapUs()
+        {
+            var businessPartnerValidations = new List<IBusinessPartnerValidation>
+            {
+                new BusinessPartnerForArValidation(Mock.Of<ILogger<BusinessPartnerForArValidation>>()),
+                new BusinessPartnerForUsValidation(Mock.Of<ILogger<BusinessPartnerForUsValidation>>())
+            };
+
+            var loggerMock = new Mock<ILogger<BusinessPartnerService>>();
+            var queuingServiceMock = new Mock<IQueuingService>();
+
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            sapConfigMock.Setup(x => x.Value)
+                .Returns(new SapConfig
+                {
+                    SapServiceConfigsBySystem = new Dictionary<string, SapServiceConfig>
+                    {
+                        { "US", new SapServiceConfig {
+                            CompanyDB = "CompanyDb",
+                            Password = "password",
+                            UserName = "Name",
+                            BaseServerUrl = "http://123.123.123/",
+                            BusinessPartnerConfig = new BusinessPartnerConfig
+                            {
+                                Endpoint = "BusinessPartners"
+                            }
+                        }
+                        }
+                    }
+                });
+
+            var businessPartnerService = new BusinessPartnerService(queuingServiceMock.Object, loggerMock.Object, sapConfigMock.Object, businessPartnerValidations);
+
+            var dopplerUser = new DopplerUserDto
+            {
+                Id = 1,
+                FirstName = "",
+                LastName = "",
+                FederalTaxID = "123",
+                PlanType = 1,
+                BillingSystemId = 2
+            };
+
+            var ex = Assert.ThrowsAsync<ValidationException>(() => businessPartnerService.CreateOrUpdateBusinessPartner(dopplerUser));
+            Assert.Equal("Invalid first name or last name.", ex.Result.Message);
+        }
+
+        [Fact]
         public void BusinessPartnerService_ShouldBeThrowsValidationException_WhenDopplerUserFederalTaxIDIsNotValid()
         {
             var businessPartnerValidations = new List<IBusinessPartnerValidation>
@@ -158,6 +257,7 @@ namespace Doppler.Sap.Test
             var dopplerUser = new DopplerUserDto
             {
                 Id = 1,
+                LastName = "Perez",
                 FederalTaxID = "",
                 PlanType = 1,
                 BillingCountryCode = "AR",
@@ -205,6 +305,7 @@ namespace Doppler.Sap.Test
             var dopplerUser = new DopplerUserDto
             {
                 Id = 1,
+                FirstName = "Juan",
                 FederalTaxID = "27111111115",
                 BillingCountryCode = "AR",
                 BillingSystemId = 9

--- a/Doppler.Sap.Test/Controllers/BusinessPartnerControllerTest.cs
+++ b/Doppler.Sap.Test/Controllers/BusinessPartnerControllerTest.cs
@@ -99,5 +99,26 @@ namespace Doppler.Sap.Test.Controllers
             Assert.IsType<BadRequestObjectResult>(response);
             Assert.Equal("Invalid plan type value.", ((ObjectResult)response).Value);
         }
+
+        [Fact]
+        public async Task CreateOrUpdateBusinessPartner_ShouldBeHttpStatusBasRequest_WhenDopplerUserFirstNameAndLastNameAreNotValid()
+        {
+            var loggerMock = new Mock<ILogger<BusinessPartnerController>>();
+            var businessPartnerServiceMock = new Mock<IBusinessPartnerService>();
+            businessPartnerServiceMock.Setup(x => x.CreateOrUpdateBusinessPartner(It.IsAny<DopplerUserDto>())).Throws(new ValidationException("Invalid first name or last name."));
+
+            var controller = new BusinessPartnerController(loggerMock.Object, businessPartnerServiceMock.Object);
+
+            // Act
+            var response = await controller.CreateOrUpdateBusinessPartner(new DopplerUserDto
+
+            {
+                PlanType = 1
+            });
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(response);
+            Assert.Equal("Invalid first name or last name.", ((ObjectResult)response).Value);
+        }
     }
 }

--- a/Doppler.Sap/Validations/BusinessPartner/BusinessPartnerForArValidation.cs
+++ b/Doppler.Sap/Validations/BusinessPartner/BusinessPartnerForArValidation.cs
@@ -28,6 +28,13 @@ namespace Doppler.Sap.Validations.BusinessPartner
                 return false;
             }
 
+            if (string.IsNullOrEmpty(dopplerUser.FirstName) && string.IsNullOrEmpty(dopplerUser.LastName))
+            {
+                _logger.LogInformation($"{dopplerUser.Email} won't be sent to SAP because it doesn't have a first name or last name");
+                error = "Invalid first name or last name.";
+                return false;
+            }
+
             if (string.IsNullOrEmpty(dopplerUser.FederalTaxID))
             {
                 _logger.LogInformation($"{dopplerUser.Email} won't be sent to SAP because it doesn't have a cuit value");

--- a/Doppler.Sap/Validations/BusinessPartner/BusinessPartnerForUsValidation.cs
+++ b/Doppler.Sap/Validations/BusinessPartner/BusinessPartnerForUsValidation.cs
@@ -33,6 +33,13 @@ namespace Doppler.Sap.Validations.BusinessPartner
                 return false;
             }
 
+            if (string.IsNullOrEmpty(dopplerUser.FirstName) && string.IsNullOrEmpty(dopplerUser.LastName))
+            {
+                _logger.LogInformation($"{dopplerUser.Email} won't be sent to SAP because it doesn't have a first name or last name");
+                error = "Invalid first name or last name.";
+                return false;
+            }
+
             if (!dopplerUser.PlanType.HasValue)
             {
                 _logger.LogInformation($"{dopplerUser.Email} won't be sent to SAP because it doesn't have a plan type id");


### PR DESCRIPTION
Add a new validation when the system try to creates or updates some business partner and this doesn't have first name and last name.

Now when the business partner has ```FirstName == ''```  and ```LastName == ''```, the endpoint throws an exception.

**Changes:**
- Add new validation.
- Add new unit tests.

**Task:** [DAT-253](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-253)