### PR TITLE
feat: send credit notes with no refund to SAP

### DIFF
--- a/Doppler.Sap.Test/BillingServiceTest.cs
+++ b/Doppler.Sap.Test/BillingServiceTest.cs
@@ -382,5 +382,142 @@ namespace Doppler.Sap.Test
             queuingServiceMock.Verify(x => x.AddToTaskQueue(It.IsAny<SapTask>()), Times.Never);
             slackServiceMock.Verify(x => x.SendNotification(It.IsAny<string>()), Times.Once);
         }
+
+        [Fact]
+        public async Task BillingService_ShouldBeAddOneTaskInQueue_WhenCreateCreditNotesHasOneValidElement()
+        {
+            var billingValidations = new List<IBillingValidation>
+            {
+                new BillingForArValidation(Mock.Of<ILogger<BillingForArValidation>>()),
+                new BillingForUsValidation(Mock.Of<ILogger<BillingForUsValidation>>())
+            };
+
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+
+            var billingMappers = new List<IBillingMapper>
+            {
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), Mock.Of<IDateTimeProvider>(), timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), Mock.Of<IDateTimeProvider>(), timeZoneConfigurations)
+            };
+
+            var queuingServiceMock = new Mock<IQueuingService>();
+            var billingService = new BillingService(queuingServiceMock.Object,
+                Mock.Of<IDateTimeProvider>(),
+                Mock.Of<ILogger<BillingService>>(),
+                Mock.Of<ISlackService>(),
+                billingMappers,
+                billingValidations);
+
+            var creditNote = new CreditNoteRequest { Amount = 100, BillingSystemId = 2, ClientId = 1, InvoiceId = 1, Type = 1 };
+
+            await billingService.CreateCreditNote(creditNote);
+
+            queuingServiceMock.Verify(x => x.AddToTaskQueue(It.IsAny<SapTask>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task BillingService_ShouldBeNotAddOneTaskInQueue_WhenCreateCreditNotesHasOneElementWithInvalidInvoiceId()
+        {
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+
+            var billingMappers = new List<IBillingMapper>
+            {
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), Mock.Of<IDateTimeProvider>(), timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), Mock.Of<IDateTimeProvider>(), timeZoneConfigurations)
+            };
+
+            var slackServiceMock = new Mock<ISlackService>();
+            slackServiceMock.Setup(x => x.SendNotification(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+            var queuingServiceMock = new Mock<IQueuingService>();
+
+            var billingService = new BillingService(queuingServiceMock.Object,
+                Mock.Of<IDateTimeProvider>(),
+                Mock.Of<ILogger<BillingService>>(),
+                slackServiceMock.Object,
+                billingMappers,
+                null);
+
+            var creditNote = new CreditNoteRequest { Amount = 100, BillingSystemId = 2, ClientId = 1, InvoiceId = 0, Type = 1 };
+
+            await billingService.CreateCreditNote(creditNote);
+
+            queuingServiceMock.Verify(x => x.AddToTaskQueue(It.IsAny<SapTask>()), Times.Never);
+            slackServiceMock.Verify(x => x.SendNotification(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task BillingService_ShouldBeNotAddOneTaskInQueue_WhenCreateCreditNotesHasOneElementWithInvalidBillingSystemId()
+        {
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+
+            var billingMappers = new List<IBillingMapper>
+            {
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), Mock.Of<IDateTimeProvider>(), timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), Mock.Of<IDateTimeProvider>(), timeZoneConfigurations)
+            };
+
+            var slackServiceMock = new Mock<ISlackService>();
+            slackServiceMock.Setup(x => x.SendNotification(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+            var queuingServiceMock = new Mock<IQueuingService>();
+
+            var billingService = new BillingService(queuingServiceMock.Object,
+                Mock.Of<IDateTimeProvider>(),
+                Mock.Of<ILogger<BillingService>>(),
+                slackServiceMock.Object,
+                billingMappers,
+                null);
+
+            var creditNote = new CreditNoteRequest { Amount = 100, BillingSystemId = 0, ClientId = 1, InvoiceId = 1, Type = 1 };
+
+            await billingService.CreateCreditNote(creditNote);
+
+            queuingServiceMock.Verify(x => x.AddToTaskQueue(It.IsAny<SapTask>()), Times.Never);
+            slackServiceMock.Verify(x => x.SendNotification(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task BillingService_ShouldBeNotAddOneTaskInQueue_WhenCreateCreditNotesHasOneElementWithInvalidClientId()
+        {
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+
+            var billingMappers = new List<IBillingMapper>
+            {
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), Mock.Of<IDateTimeProvider>(), timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), Mock.Of<IDateTimeProvider>(), timeZoneConfigurations)
+            };
+
+            var slackServiceMock = new Mock<ISlackService>();
+            slackServiceMock.Setup(x => x.SendNotification(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+            var queuingServiceMock = new Mock<IQueuingService>();
+
+            var billingService = new BillingService(queuingServiceMock.Object,
+                Mock.Of<IDateTimeProvider>(),
+                Mock.Of<ILogger<BillingService>>(),
+                slackServiceMock.Object,
+                billingMappers,
+                null);
+
+            var creditNote = new CreditNoteRequest { Amount = 100, BillingSystemId = 2, ClientId = 0, InvoiceId = 1, Type = 1 };
+
+            await billingService.CreateCreditNote(creditNote);
+
+            queuingServiceMock.Verify(x => x.AddToTaskQueue(It.IsAny<SapTask>()), Times.Never);
+            slackServiceMock.Verify(x => x.SendNotification(It.IsAny<string>()), Times.Once);
+        }
     }
 }

--- a/Doppler.Sap.Test/Controllers/BillingControllerTest.cs
+++ b/Doppler.Sap.Test/Controllers/BillingControllerTest.cs
@@ -98,5 +98,78 @@ namespace Doppler.Sap.Test.Controllers
             // Assert
             Assert.Equal("Value can not be null (Parameter 'InvoiceId')", ex.Result.Message);
         }
+
+        [Fact]
+        public async Task CreateCreditNotes_ShouldBeHttpStatusCodeOk_WhenRequestIsValid()
+        {
+            var creditNote = new CreditNoteRequest { Amount = 100, BillingSystemId = 2, ClientId = 1, InvoiceId = 1, Type = 1 };
+
+            var loggerMock = new Mock<ILogger<BillingController>>();
+            var billingServiceMock = new Mock<IBillingService>();
+            billingServiceMock.Setup(x => x.CreateCreditNote(It.IsAny<CreditNoteRequest>()))
+                .Returns(Task.CompletedTask);
+
+            var controller = new BillingController(loggerMock.Object, billingServiceMock.Object);
+
+            // Act
+            var response = await controller.CreateCreditNote(creditNote);
+
+            // Assert
+            Assert.IsType<OkObjectResult>(response);
+            Assert.Equal("Successfully", ((ObjectResult)response).Value);
+        }
+
+        [Fact]
+        public void CreateCreditNotes_ShouldBeThrowsAnException_WhenInvoiceIdIsNotValid()
+        {
+            var creditNote = new CreditNoteRequest { Amount = 100, BillingSystemId = 2, ClientId = 1, InvoiceId = 0, Type = 1 };
+            var loggerMock = new Mock<ILogger<BillingController>>();
+            var billingServiceMock = new Mock<IBillingService>();
+            billingServiceMock.Setup(x => x.CreateCreditNote(It.IsAny<CreditNoteRequest>())).ThrowsAsync(new ArgumentException("Value can not be null", "InvoiceId"));
+
+            var controller = new BillingController(loggerMock.Object, billingServiceMock.Object);
+
+            // Act
+            var ex = Assert.ThrowsAsync<ArgumentException>(() => controller.CreateCreditNote(creditNote));
+
+            // Assert
+            Assert.Equal("Value can not be null (Parameter 'InvoiceId')", ex.Result.Message);
+        }
+
+        [Fact]
+        public void CreateCreditNotes_ShouldBeThrowsAnException_WhenBillingSystemIdIsNotValid()
+        {
+            var creditNote = new CreditNoteRequest { Amount = 100, BillingSystemId = 0, ClientId = 1, InvoiceId = 1, Type = 1 };
+
+            var loggerMock = new Mock<ILogger<BillingController>>();
+            var billingServiceMock = new Mock<IBillingService>();
+            billingServiceMock.Setup(x => x.CreateCreditNote(It.IsAny<CreditNoteRequest>())).ThrowsAsync(new ArgumentException("Value can not be null", "BillingSystemId"));
+
+            var controller = new BillingController(loggerMock.Object, billingServiceMock.Object);
+
+            // Act
+            var ex = Assert.ThrowsAsync<ArgumentException>(() => controller.CreateCreditNote(creditNote));
+
+            // Assert
+            Assert.Equal("Value can not be null (Parameter 'BillingSystemId')", ex.Result.Message);
+        }
+
+        [Fact]
+        public void CreateCreditNotes_ShouldBeThrowsAnException_WhenClientIdIsNotValid()
+        {
+            var creditNote = new CreditNoteRequest { Amount = 100, BillingSystemId = 2, ClientId = 0, InvoiceId = 1, Type = 1 };
+
+            var loggerMock = new Mock<ILogger<BillingController>>();
+            var billingServiceMock = new Mock<IBillingService>();
+            billingServiceMock.Setup(x => x.CreateCreditNote(It.IsAny<CreditNoteRequest>())).ThrowsAsync(new ArgumentException("Value can not be null", "ClientId"));
+
+            var controller = new BillingController(loggerMock.Object, billingServiceMock.Object);
+
+            // Act
+            var ex = Assert.ThrowsAsync<ArgumentException>(() => controller.CreateCreditNote(creditNote));
+
+            // Assert
+            Assert.Equal("Value can not be null (Parameter 'ClientId')", ex.Result.Message);
+        }
     }
 }

--- a/Doppler.Sap.Test/CreditNoteHandlerTest.cs
+++ b/Doppler.Sap.Test/CreditNoteHandlerTest.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Doppler.Sap.Factory;
+using Doppler.Sap.Mappers.Billing;
+using Doppler.Sap.Models;
+using Doppler.Sap.Services;
+using Doppler.Sap.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Doppler.Sap.Test
+{
+    public class CreditNoteHandlerTest
+    {
+        [Fact]
+        public async Task CreditNoteHandler_ShouldBeCreateCreditNoteInSap_WhenQueueHasOneValidElement()
+        {
+            var sapSaleOrderInvoiceResponse = new SapSaleOrderInvoiceResponse
+            {
+                BillingSystemId = 2,
+                CardCode = "CD001",
+                DocumentLines = new List<SapDocumentLineResponse>()
+            };
+
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+
+            var dateTimeProviderMock = new Mock<IDateTimeProvider>();
+            dateTimeProviderMock.Setup(x => x.UtcNow)
+                .Returns(new DateTime(2019, 09, 25));
+
+            var billingMappers = new List<IBillingMapper>
+            {
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations)
+            };
+
+            sapConfigMock.Setup(x => x.Value)
+                .Returns(new SapConfig
+                {
+                    SapServiceConfigsBySystem = new Dictionary<string, SapServiceConfig>
+                    {
+                        { "US", new SapServiceConfig {
+                            CompanyDB = "CompanyDb",
+                            Password = "password",
+                            UserName = "Name",
+                            BaseServerUrl = "http://123.123.123/",
+                            BusinessPartnerConfig = new BusinessPartnerConfig
+                            {
+                                Endpoint = "BusinessPartners"
+                            },
+                            BillingConfig = new BillingConfig
+                            {
+                                Endpoint = "Invoices",
+                                CreditNotesEndpoint = "CreditNotes"
+                            }
+                        }
+                        }
+                    }
+                });
+
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            httpMessageHandlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(@"")
+                });
+            var httpClient = new HttpClient(httpMessageHandlerMock.Object);
+
+            httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient);
+
+            var sapTaskHandlerMock = new Mock<ISapTaskHandler>();
+            sapTaskHandlerMock.Setup(x => x.StartSession())
+                .ReturnsAsync(new SapLoginCookies
+                {
+                    B1Session = "session",
+                    RouteId = "route"
+                });
+
+
+            sapTaskHandlerMock.Setup(x => x.TryGetInvoiceByInvoiceId(It.IsAny<int>()))
+                .ReturnsAsync(sapSaleOrderInvoiceResponse);
+
+            var sapServiceSettingsFactoryMock = new Mock<ISapServiceSettingsFactory>();
+            sapServiceSettingsFactoryMock.Setup(x => x.CreateHandler("US")).Returns(sapTaskHandlerMock.Object);
+
+            var handler = new CreditNoteHandler(
+                sapConfigMock.Object,
+                Mock.Of<ILogger<CreditNoteHandler>>(),
+                sapServiceSettingsFactoryMock.Object,
+                httpClientFactoryMock.Object,
+                billingMappers);
+
+            var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("")
+            };
+
+            httpResponseMessage.Headers.Add("Set-Cookie", "");
+            httpMessageHandlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(httpResponseMessage);
+
+            var result = await handler.Handle(new SapTask
+            {
+                CreditNoteRequest = new CreditNoteRequest
+                {
+                    BillingSystemId = 2,
+                    Amount = 100,
+                    ClientId = 1,
+                    InvoiceId = 1,
+                    Type = 1
+                },
+                TaskType = Enums.SapTaskEnum.CreateCreditNote
+            });
+
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("Creating Credit Note Request", result.TaskName);
+        }
+
+        [Fact]
+        public async Task CreditNoteHandler_ShouldBeNotCreateCreditNoteInSap_WhenQueueHasOneElementButInvoiceNotExistsInSAP()
+        {
+            var sapConfigMock = new Mock<IOptions<SapConfig>>();
+            var timeZoneConfigurations = new TimeZoneConfigurations
+            {
+                InvoicesTimeZone = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time")
+            };
+            var dateTimeProviderMock = new Mock<IDateTimeProvider>();
+            dateTimeProviderMock.Setup(x => x.UtcNow)
+                .Returns(new DateTime(2019, 09, 25));
+
+            var billingMappers = new List<IBillingMapper>
+            {
+                new BillingForArMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations),
+                new BillingForUsMapper(Mock.Of<ISapBillingItemsService>(), dateTimeProviderMock.Object, timeZoneConfigurations)
+            };
+
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            httpMessageHandlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(@"")
+                });
+            var httpClient = new HttpClient(httpMessageHandlerMock.Object);
+
+            httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient);
+
+            var sapTaskHandlerMock = new Mock<ISapTaskHandler>();
+            sapTaskHandlerMock.Setup(x => x.StartSession())
+                .ReturnsAsync(new SapLoginCookies
+                {
+                    B1Session = "session",
+                    RouteId = "route"
+                });
+
+            sapTaskHandlerMock.Setup(x => x.TryGetInvoiceByInvoiceId(It.IsAny<int>()))
+                .ReturnsAsync((SapSaleOrderInvoiceResponse)null);
+
+            var sapServiceSettingsFactoryMock = new Mock<ISapServiceSettingsFactory>();
+            sapServiceSettingsFactoryMock.Setup(x => x.CreateHandler("US")).Returns(sapTaskHandlerMock.Object);
+
+            var handler = new CreditNoteHandler(
+                sapConfigMock.Object,
+                Mock.Of<ILogger<CreditNoteHandler>>(),
+                sapServiceSettingsFactoryMock.Object,
+                httpClientFactoryMock.Object,
+                billingMappers);
+
+            var sapTask = new SapTask
+            {
+                CreditNoteRequest = new CreditNoteRequest
+                {
+                    BillingSystemId = 2,
+                    Amount = 100,
+                    ClientId = 1,
+                    InvoiceId = 1,
+                    Type = 1
+                },
+                TaskType = Enums.SapTaskEnum.CreateCreditNote
+            };
+
+            var result = await handler.Handle(sapTask);
+
+            Assert.False(result.IsSuccessful);
+            Assert.Equal($"Credit Note could'n create to SAP because the invoice does not exist: '{sapTask.CreditNoteRequest.InvoiceId}'.", result.SapResponseContent);
+            Assert.Equal("Creating Credit Note Request", result.TaskName);
+        }
+    }
+}

--- a/Doppler.Sap/Controllers/BillingController.cs
+++ b/Doppler.Sap/Controllers/BillingController.cs
@@ -52,5 +52,15 @@ namespace Doppler.Sap.Controllers
 
             return new OkObjectResult("Successfully");
         }
+
+        [HttpPost("CreateCreditNote")]
+        public async Task<IActionResult> CreateCreditNote([FromBody] CreditNoteRequest creditNoteRequest)
+        {
+            _logger.LogDebug("Creating Credit Note");
+
+            await _billingService.CreateCreditNote(creditNoteRequest);
+
+            return new OkObjectResult("Successfully");
+        }
     }
 }

--- a/Doppler.Sap/Enums/CreditNoteEnum.cs
+++ b/Doppler.Sap/Enums/CreditNoteEnum.cs
@@ -1,0 +1,8 @@
+namespace Doppler.Sap.Enums
+{
+    public enum CreditNoteEnum
+    {
+        NoRefund = 1,
+        Refund = 2
+    }
+}

--- a/Doppler.Sap/Enums/SapTaskEnum.cs
+++ b/Doppler.Sap/Enums/SapTaskEnum.cs
@@ -5,6 +5,7 @@ namespace Doppler.Sap.Enums
         CreateOrUpdateBusinessPartner = 1,
         BillingRequest = 2,
         CurrencyRate = 3,
-        UpdateBilling = 4
+        UpdateBilling = 4,
+        CreateCreditNote = 5
     }
 }

--- a/Doppler.Sap/Factory/CreditNoteHandler.cs
+++ b/Doppler.Sap/Factory/CreditNoteHandler.cs
@@ -1,0 +1,136 @@
+using Doppler.Sap.Mappers.Billing;
+using Doppler.Sap.Models;
+using Doppler.Sap.Utils;
+using Doppler.Sap.Validations.Billing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Doppler.Sap.Factory
+{
+    public class CreditNoteHandler
+    {
+        private readonly ISapServiceSettingsFactory _sapServiceSettingsFactory;
+        private readonly ILogger<CreditNoteHandler> _logger;
+        private readonly SapConfig _sapConfig;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IEnumerable<IBillingMapper> _billingMappers;
+
+        public CreditNoteHandler(
+            IOptions<SapConfig> sapConfig,
+            ILogger<CreditNoteHandler> logger,
+            ISapServiceSettingsFactory sapServiceSettingsFactory,
+            IHttpClientFactory httpClientFactory,
+            IEnumerable<IBillingMapper> billingMappers)
+        {
+            _sapConfig = sapConfig.Value;
+            _logger = logger;
+            _sapServiceSettingsFactory = sapServiceSettingsFactory;
+            _httpClientFactory = httpClientFactory;
+            _billingMappers = billingMappers;
+        }
+
+        public async Task<SapTaskResult> Handle(SapTask dequeuedTask)
+        {
+            try
+            {
+                var sapSystem = SapSystemHelper.GetSapSystemByBillingSystem(dequeuedTask.CreditNoteRequest.BillingSystemId);
+                var sapTaskHandler = _sapServiceSettingsFactory.CreateHandler(sapSystem);
+                var existentInvoice = await sapTaskHandler.TryGetInvoiceByInvoiceId(dequeuedTask.CreditNoteRequest.InvoiceId);
+
+                if (existentInvoice != null)
+                {
+                    var sapResponse = await CreateCreditNote(existentInvoice, dequeuedTask, sapSystem);
+
+                    if (!sapResponse.IsSuccessful)
+                    {
+                        _logger.LogError($"Credit Note could'n create to SAP because exists an error: '{sapResponse.SapResponseContent}'.");
+                    }
+
+                    return sapResponse;
+                }
+                else
+                {
+                    return new SapTaskResult
+                    {
+                        IsSuccessful = false,
+                        SapResponseContent = $"Credit Note could'n create to SAP because the invoice does not exist: '{dequeuedTask.CreditNoteRequest.InvoiceId}'.",
+                        TaskName = "Creating Credit Note Request"
+                    };
+                }
+            }
+            catch (Exception ex)
+            {
+                return new SapTaskResult
+                {
+                    IsSuccessful = false,
+                    SapResponseContent = ex.Message,
+                    TaskName = "Creating Credit Note Request"
+                };
+            }
+        }
+
+        private async Task<SapTaskResult> CreateCreditNote(SapSaleOrderInvoiceResponse sapSaleOrderInvoiceResponse, SapTask dequeuedTask, string sapSystem)
+        {
+
+            var sapCreditNote = GetMapper(sapSystem).MapToSapCreditNote(sapSaleOrderInvoiceResponse, dequeuedTask.CreditNoteRequest.Type);
+            sapCreditNote.BillingSystemId = dequeuedTask.CreditNoteRequest.BillingSystemId;
+            sapCreditNote.DocTotal = dequeuedTask.CreditNoteRequest.Amount;
+
+            var serviceSetting = SapServiceSettings.GetSettings(_sapConfig, sapSystem);
+            var uriString = $"{serviceSetting.BaseServerUrl}{serviceSetting.BillingConfig.CreditNotesEndpoint}";
+            var sapResponse = await SendMessage(sapCreditNote, sapSystem, uriString, HttpMethod.Post);
+
+            return new SapTaskResult
+            {
+                IsSuccessful = sapResponse.IsSuccessStatusCode,
+                SapResponseContent = await sapResponse.Content.ReadAsStringAsync(),
+                TaskName = "Creating Credit Note Request"
+            };
+        }
+
+        private IBillingMapper GetMapper(string sapSystem)
+        {
+            // Check if exists business partner mapper for the sapSystem
+            var mapper = _billingMappers.FirstOrDefault(m => m.CanMapSapSystem(sapSystem));
+            if (mapper == null)
+            {
+                _logger.LogError($"Billing Request won't be sent to SAP because the sapSystem '{sapSystem}' is not supported.");
+                throw new ArgumentException(nameof(sapSystem), $"The sapSystem '{sapSystem}' is not supported.");
+            }
+
+            return mapper;
+        }
+
+        private async Task<HttpResponseMessage> SendMessage(SapCreditNoteModel creditNote, string sapSystem, string uriString, HttpMethod method)
+        {
+            var message = new HttpRequestMessage()
+            {
+                RequestUri = new Uri(uriString),
+                Content = new StringContent(JsonConvert.SerializeObject(creditNote,
+                    new JsonSerializerSettings
+                    {
+                        NullValueHandling = NullValueHandling.Ignore,
+                        DefaultValueHandling = DefaultValueHandling.Ignore
+                    }),
+                    Encoding.UTF8,
+                    "application/json"),
+                Method = method
+            };
+
+            var sapTaskHandler = _sapServiceSettingsFactory.CreateHandler(sapSystem);
+            var cookies = await sapTaskHandler.StartSession();
+            message.Headers.Add("Cookie", cookies.B1Session);
+            message.Headers.Add("Cookie", cookies.RouteId);
+
+            var client = _httpClientFactory.CreateClient();
+            return await client.SendAsync(message);
+        }
+    }
+}

--- a/Doppler.Sap/Factory/SapTaskFactory.cs
+++ b/Doppler.Sap/Factory/SapTaskFactory.cs
@@ -25,6 +25,8 @@ namespace Doppler.Sap.Factory
                     return await ((BillingRequestHandler)_serviceProvider.GetService(typeof(BillingRequestHandler))).Handle(sapTask);
                 case SapTaskEnum.CreateOrUpdateBusinessPartner:
                     return await ((CreateOrUpdateBusinessPartnerHandler)_serviceProvider.GetService(typeof(CreateOrUpdateBusinessPartnerHandler))).Handle(sapTask);
+                case SapTaskEnum.CreateCreditNote:
+                    return await ((CreditNoteHandler)_serviceProvider.GetService(typeof(CreditNoteHandler))).Handle(sapTask);
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Doppler.Sap/Mappers/Billing/IBillingMapper.cs
+++ b/Doppler.Sap/Mappers/Billing/IBillingMapper.cs
@@ -10,5 +10,6 @@ namespace Doppler.Sap.Mappers.Billing
         SapIncomingPaymentModel MapSapIncomingPayment(int docEntry, string cardCode, decimal docTotal, DateTime docDate, string transferReference);
 
         SapSaleOrderModel MapDopplerUpdateBillingRequestToSapSaleOrder(UpdatePaymentStatusRequest updateBillingRequest);
+        SapCreditNoteModel MapToSapCreditNote(SapSaleOrderInvoiceResponse sapSaleOrderInvoiceResponse, int creditNoteType);
     }
 }

--- a/Doppler.Sap/Models/BillingConfig.cs
+++ b/Doppler.Sap/Models/BillingConfig.cs
@@ -7,5 +7,6 @@ namespace Doppler.Sap.Models
         public bool NeedCreateIncomingPayments { get; set; }
 
         public string IncomingPaymentsEndpoint { get; set; }
+        public string CreditNotesEndpoint { get; set; }
     }
 }

--- a/Doppler.Sap/Models/CreditNoteRequest.cs
+++ b/Doppler.Sap/Models/CreditNoteRequest.cs
@@ -1,0 +1,11 @@
+namespace Doppler.Sap.Models
+{
+    public class CreditNoteRequest
+    {
+        public int InvoiceId { get; set; }
+        public double Amount { get; set; }
+        public int ClientId { get; set; }
+        public int BillingSystemId { get; set; }
+        public int Type { get; set; }
+    }
+}

--- a/Doppler.Sap/Models/SapCreditNoteDocumentLineModel.cs
+++ b/Doppler.Sap/Models/SapCreditNoteDocumentLineModel.cs
@@ -1,0 +1,20 @@
+namespace Doppler.Sap.Models
+{
+    public class SapCreditNoteDocumentLineModel
+    {
+        public string TaxCode { get; set; }
+        public string ItemCode { get; set; }
+        public double Quantity { get; set; }
+        public double UnitPrice { get; set; }
+        public string Currency { get; set; }
+        public string FreeText { get; set; }
+        public string CostingCode { get; set; }
+        public string CostingCode2 { get; set; }
+        public string CostingCode3 { get; set; }
+        public string CostingCode4 { get; set; }
+        public int? DiscountPercent { get; set; }
+        public int BaseType { get; set; }
+        public int BaseEntry { get; set; }
+        public int? BaseLine { get; set; }
+    }
+}

--- a/Doppler.Sap/Models/SapCreditNoteModel.cs
+++ b/Doppler.Sap/Models/SapCreditNoteModel.cs
@@ -1,21 +1,21 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Doppler.Sap.Models
 {
-    public class SapSaleOrderInvoiceResponse
+    public class SapCreditNoteModel
     {
+        public int InvoiceId { get; set; }
         public string CardCode { get; set; }
-        public int DocEntry { get; set; }
-        public DateTime DocDate { get; set; }
-        public decimal DocTotal { get; set; }
-        public int DocNum { get; set; }
+        public string DocDate { get; set; }
+        public string DocDueDate { get; set; }
+        public double DocTotal { get; set; }
         public string TaxDate { get; set; }
         public string NumAtCard { get; set; }
         public string U_DPL_RECURRING_SERV { get; set; }
-        public List<SapDocumentLineResponse> DocumentLines { get; set; }
+        public List<SapCreditNoteDocumentLineModel> DocumentLines { get; set; }
+        public string FiscalID { get; set; }
+        public int UserId { get; set; }
+        public int PlanType { get; set; }
         public int BillingSystemId { get; set; }
         public string U_DPL_CARD_HOLDER { get; set; }
         public string U_DPL_CARD_NUMBER { get; set; }

--- a/Doppler.Sap/Models/SapDocumentLineResponse.cs
+++ b/Doppler.Sap/Models/SapDocumentLineResponse.cs
@@ -1,0 +1,19 @@
+
+namespace Doppler.Sap.Models
+{
+    public class SapDocumentLineResponse
+    {
+        public int LineNum { get; set; }
+        public string TaxCode { get; set; }
+        public string ItemCode { get; set; }
+        public double Quantity { get; set; }
+        public double UnitPrice { get; set; }
+        public string Currency { get; set; }
+        public string FreeText { get; set; }
+        public string CostingCode { get; set; }
+        public string CostingCode2 { get; set; }
+        public string CostingCode3 { get; set; }
+        public string CostingCode4 { get; set; }
+        public double DiscountPercent { get; set; }
+    }
+}

--- a/Doppler.Sap/Models/SapTask.cs
+++ b/Doppler.Sap/Models/SapTask.cs
@@ -9,6 +9,7 @@ namespace Doppler.Sap.Models
         public DopplerUserDto DopplerUser { get; set; }
         public SapCurrencyRate CurrencyRate { get; set; }
         public SapSaleOrderModel BillingRequest { get; set; }
+        public CreditNoteRequest CreditNoteRequest { get; set; }
         public SapTaskEnum TaskType { get; set; }
     }
 }

--- a/Doppler.Sap/Services/DummyBillingService.cs
+++ b/Doppler.Sap/Services/DummyBillingService.cs
@@ -20,5 +20,10 @@ namespace Doppler.Sap.Services
         {
             return Task.CompletedTask;
         }
+
+        public Task CreateCreditNote(CreditNoteRequest creditNotesRequest)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/Doppler.Sap/Services/IBillingService.cs
+++ b/Doppler.Sap/Services/IBillingService.cs
@@ -10,5 +10,6 @@ namespace Doppler.Sap.Services
         Task CreateBillingRequest(List<BillingRequest> billingRequests);
 
         Task UpdatePaymentStatus(UpdatePaymentStatusRequest updateBillingRequest);
+        Task CreateCreditNote(CreditNoteRequest creditNotesRequest);
     }
 }

--- a/Doppler.Sap/Startup.cs
+++ b/Doppler.Sap/Startup.cs
@@ -94,6 +94,7 @@ namespace Doppler.Sap
 
             services.AddTransient<SetCurrencyRateHandler>();
             services.AddTransient<BillingRequestHandler>();
+            services.AddTransient<CreditNoteHandler>();
             services.AddTransient<CreateOrUpdateBusinessPartnerHandler>();
             services.AddTransient<ISapTaskFactory, SapTaskFactory>();
             services.AddTransient<ISapServiceSettingsFactory, SapServiceSettingsFactory>();

--- a/Doppler.Sap/Validations/Billing/BillingForArValidation.cs
+++ b/Doppler.Sap/Validations/Billing/BillingForArValidation.cs
@@ -70,5 +70,26 @@ namespace Doppler.Sap.Validations.Billing
                 throw new ArgumentException("Value can not be null", "InvoiceId");
             }
         }
+
+        public void ValidateCreditNoteRequest(CreditNoteRequest creditNoteRequest)
+        {
+            if (creditNoteRequest.InvoiceId.Equals(default))
+            {
+                _logger.LogError("Create Credit Note Request won't be sent to SAP because it doesn't have the invoice's Id.");
+                throw new ArgumentException("Value can not be null", "InvoiceId");
+            }
+
+            if (creditNoteRequest.BillingSystemId.Equals(default))
+            {
+                _logger.LogError("Create Credit Note Request won't be sent to SAP because it doesn't have the billing system's Id.");
+                throw new ArgumentException("Value can not be null", "BillingSystemId");
+            }
+
+            if (creditNoteRequest.ClientId.Equals(default))
+            {
+                _logger.LogError("Create Credit Note Request won't be sent to SAP because it doesn't have the client's Id.");
+                throw new ArgumentException("Value can not be null", "ClientId");
+            }
+        }
     }
 }

--- a/Doppler.Sap/Validations/Billing/BillingForUsValidation.cs
+++ b/Doppler.Sap/Validations/Billing/BillingForUsValidation.cs
@@ -58,5 +58,26 @@ namespace Doppler.Sap.Validations.Billing
                 throw new ArgumentException("Value can not be null", "InvoiceId");
             }
         }
+
+        public void ValidateCreditNoteRequest(CreditNoteRequest creditNoteRequest)
+        {
+            if (creditNoteRequest.InvoiceId.Equals(default))
+            {
+                _logger.LogError("Create Credit Note Request won't be sent to SAP because it doesn't have the invoice's Id.");
+                throw new ArgumentException("Value can not be null", "InvoiceId");
+            }
+
+            if (creditNoteRequest.BillingSystemId.Equals(default))
+            {
+                _logger.LogError("Create Credit Note Request won't be sent to SAP because it doesn't have the billing system's Id.");
+                throw new ArgumentException("Value can not be null", "BillingSystemId");
+            }
+
+            if (creditNoteRequest.ClientId.Equals(default))
+            {
+                _logger.LogError("Create Credit Note Request won't be sent to SAP because it doesn't have the client's Id.");
+                throw new ArgumentException("Value can not be null", "ClientId");
+            }
+        }
     }
 }

--- a/Doppler.Sap/Validations/Billing/IBillingValidation.cs
+++ b/Doppler.Sap/Validations/Billing/IBillingValidation.cs
@@ -13,5 +13,7 @@ namespace Doppler.Sap.Validations.Billing
         void ValidateRequest(BillingRequest dopplerBillingRequest);
 
         void ValidateUpdateRequest(UpdatePaymentStatusRequest updateBillingRequest);
+
+        void ValidateCreditNoteRequest(CreditNoteRequest creditNoteRequest);
     }
 }

--- a/Doppler.Sap/appsettings.json
+++ b/Doppler.Sap/appsettings.json
@@ -23,7 +23,8 @@
         },
         "BillingConfig": {
           "Endpoint": "Orders",
-          "NeedCreateIncomingPayments": false
+          "NeedCreateIncomingPayments": false,
+          "CreditNotesEndpoint": "CreditNotes"
         }
       },
       "US": {
@@ -36,7 +37,8 @@
         "BillingConfig": {
           "Endpoint": "Invoices",
           "NeedCreateIncomingPayments": true,
-          "IncomingPaymentsEndpoint": "IncomingPayments"
+          "IncomingPaymentsEndpoint": "IncomingPayments",
+          "CreditNotesEndpoint": "CreditNotes"
         }
       }
     },


### PR DESCRIPTION
Allow to create a credit note with no refund  in SAP.

**Changes:**

- Added new endpoint to create a credit note in SAP.
- Add new UTs.

**Task:** [DAT-266](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-266)