### PR TITLE
Fix: [DAT-292] Fix invoice detail for Individual clients of Doppler

### DIFF
--- a/Doppler.Sap/Mappers/Billing/BillingForArMapper.cs
+++ b/Doppler.Sap/Mappers/Billing/BillingForArMapper.cs
@@ -69,7 +69,7 @@ namespace Doppler.Sap.Mappers.Billing
                 Amount = $"{currencyCode} {billingRequest.PlanFee.ToString(CultureInfo.CurrentCulture)} + IMP",
                 Periodicity = billingRequest.Periodicity != null ? $"Plan {(Dictionary.PeriodicityDictionary.TryGetValue(billingRequest.Periodicity, out var outPeriodicity) ? outPeriodicity : string.Empty)}" : null,
                 Discount = billingRequest.Discount > 0 ? $"Descuento {billingRequest.Discount}%" : null,
-                Payment = $"Abono {billingRequest.PeriodMonth:00} {billingRequest.PeriodYear}",
+                Payment = billingRequest.Periodicity != null ? $"Abono {billingRequest.PeriodMonth:00} {billingRequest.PeriodYear}" : string.Empty
             };
 
             planItem.FreeText = string.Join(" - ", new string[] { freeText.Amount, freeText.Periodicity, freeText.Discount, freeText.Payment }.Where(s => !string.IsNullOrEmpty(s)));

--- a/Doppler.Sap/Mappers/Billing/BillingForUsMapper.cs
+++ b/Doppler.Sap/Mappers/Billing/BillingForUsMapper.cs
@@ -92,7 +92,7 @@ namespace Doppler.Sap.Mappers.Billing
                     Amount = $"{_currencyCode} {billingRequest.PlanFee.ToString(CultureInfo.CurrentCulture)}",
                     Periodicity = billingRequest.Periodicity != null ? $" {(periodicities.TryGetValue(billingRequest.Periodicity, out var outPeriodicity2) ? outPeriodicity2 : string.Empty)} Plan " : null,
                     Discount = billingRequest.Discount > 0 ? $"{billingRequest.Discount}% OFF" : null,
-                    Payment = $"Period {billingRequest.PeriodMonth:00} {billingRequest.PeriodYear}",
+                    Payment = billingRequest.Periodicity != null ? $"Period {billingRequest.PeriodMonth:00} {billingRequest.PeriodYear}" : string.Empty
                 };
 
                 planItem.FreeText = string.Join(" - ", new string[] { freeText.Amount, freeText.Periodicity, freeText.Discount, freeText.Payment }.Where(s => !string.IsNullOrEmpty(s)));


### PR DESCRIPTION
# Background
We need to change the description to remove unnecessary text for Individual Doppler clients

Examples:

Individual
![image](https://user-images.githubusercontent.com/6796523/107641698-aff32e00-6c52-11eb-9a54-954089114184.png)

Monthly
![image (1)](https://user-images.githubusercontent.com/6796523/107641745-c0a3a400-6c52-11eb-829b-4ef45a81e07d.png)
