### PR TITLE
[DAT-279]  Create a Credit note without refund - Add Reason selector 

### DIFF
--- a/Doppler.Sap/Mappers/Billing/BillingForArMapper.cs
+++ b/Doppler.Sap/Mappers/Billing/BillingForArMapper.cs
@@ -180,7 +180,8 @@ namespace Doppler.Sap.Mappers.Billing
                     ItemCode = line.ItemCode,
                     Quantity = line.Quantity,
                     TaxCode = line.TaxCode,
-                    UnitPrice = amount
+                    UnitPrice = amount,
+                    ReturnReason = -1
                 };
 
                 sapCreditNoteModel.DocumentLines.Add(creditNoteLine);

--- a/Doppler.Sap/Mappers/Billing/BillingForUsMapper.cs
+++ b/Doppler.Sap/Mappers/Billing/BillingForUsMapper.cs
@@ -34,6 +34,22 @@ namespace Doppler.Sap.Mappers.Billing
             {3, "12 months"}
         };
 
+        private readonly Dictionary<string, int> _creditNoteReason = new Dictionary<string, int>
+        {
+            {"Account cancellation", 1},
+            {"Bonus", 2},
+            {"Rebilling", 3},
+            {"Chargeback", 4},
+            {"Payment method change", 5},
+            {"First data refund", 6},
+            {"Doppler failure bonus", 7},
+            {"Plan change", 8},
+            {"Doppler failure refund", 10},
+            {"Duplicated invoice", 11},
+            { "Transfer refund", 13},
+            {"Credits purchase cancellation", 14},
+            {"Credit memo without refund - account cancellation", 15}
+        };
 
         public BillingForUsMapper(ISapBillingItemsService sapBillingItemsService, IDateTimeProvider dateTimeProvider, TimeZoneConfigurations timezoneConfig)
         {
@@ -258,7 +274,9 @@ namespace Doppler.Sap.Mappers.Billing
                     ItemCode = line.ItemCode,
                     Quantity = line.Quantity,
                     TaxCode = line.TaxCode,
-                    UnitPrice = amount
+                    UnitPrice = amount,
+                    ReturnReason = string.IsNullOrEmpty(creditNoteRequest.Reason) ? -1 :
+                    _creditNoteReason.TryGetValue(creditNoteRequest.Reason, out var outReason) ? outReason : -1
                 };
 
                 sapCreditNoteModel.DocumentLines.Add(creditNoteLine);

--- a/Doppler.Sap/Models/CreditNoteRequest.cs
+++ b/Doppler.Sap/Models/CreditNoteRequest.cs
@@ -12,5 +12,6 @@ namespace Doppler.Sap.Models
         public string CardErrorDetail { get; set; }
         public bool TransactionApproved { get; set; }
         public string TransferReference { get; set; }
+        public string Reason { get; set; }
     }
 }

--- a/Doppler.Sap/Models/SapCreditNoteDocumentLineModel.cs
+++ b/Doppler.Sap/Models/SapCreditNoteDocumentLineModel.cs
@@ -16,5 +16,6 @@ namespace Doppler.Sap.Models
         public int? BaseType { get; set; }
         public int? BaseEntry { get; set; }
         public int? BaseLine { get; set; }
+        public int ReturnReason { get; set; }
     }
 }


### PR DESCRIPTION
# Background
When an admin creates a new note credit without refund, We need to add a reason, so for this property in CreateCreditNote endpoint