### PR TITLE
[DAT-273] - Rename contactId when the client has 2 o more repeated id in the contacts

### DIFF
--- a/Doppler.Sap.Test/Mappers/BusinessPartnerForArMapperTest.cs
+++ b/Doppler.Sap.Test/Mappers/BusinessPartnerForArMapperTest.cs
@@ -148,5 +148,55 @@ namespace Doppler.Sap.Test.Mappers
 
             Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
         }
+
+        [Fact]
+        public void BusinessPartnerForUsMapper_ShouldBeSetDifferentContactId_WhenTheClientHasTheSameUserIdForDifferentEmail()
+        {
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 2,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingEmails = new string[] { "test@gmail.com" },
+                BillingSystemId = 2
+            };
+
+            var mapper = new BusinessPartnerForArMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal("test1", sapBusinessPartner.ContactEmployees[0].Name);
+            Assert.Equal("test2", sapBusinessPartner.ContactEmployees[1].Name);
+        }
+
+        [Fact]
+        public void BusinessPartnerForUsMapper_ShouldBeSetCurrentContactId_WhenTheClientHasTheDifferentUserIdForDifferentEmail()
+        {
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 2,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingEmails = new string[] { "test1@gmail.com" },
+                BillingSystemId = 2
+            };
+
+            var mapper = new BusinessPartnerForArMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal("test1", sapBusinessPartner.ContactEmployees[0].Name);
+            Assert.Equal("test", sapBusinessPartner.ContactEmployees[1].Name);
+        }
     }
 }

--- a/Doppler.Sap.Test/Mappers/BusinessPartnerForUsMapperTest.cs
+++ b/Doppler.Sap.Test/Mappers/BusinessPartnerForUsMapperTest.cs
@@ -148,5 +148,55 @@ namespace Doppler.Sap.Test.Mappers
 
             Assert.Equal(groupCode, sapBusinessPartner.GroupCode);
         }
+
+        [Fact]
+        public void BusinessPartnerForUsMapper_ShouldBeSetDifferentContactId_WhenTheClientHasTheSameUserIdForDifferentEmail()
+        {
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 2,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingEmails = new string[] { "test@gmail.com" },
+                BillingSystemId = 2
+            };
+
+            var mapper = new BusinessPartnerForUsMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal("test1", sapBusinessPartner.ContactEmployees[0].Name);
+            Assert.Equal("test2", sapBusinessPartner.ContactEmployees[1].Name);
+        }
+
+        [Fact]
+        public void BusinessPartnerForUsMapper_ShouldBeSetCurrentContactId_WhenTheClientHasTheDifferentUserIdForDifferentEmail()
+        {
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 2,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingEmails = new string[] { "test1@gmail.com" },
+                BillingSystemId = 2
+            };
+
+            var mapper = new BusinessPartnerForUsMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal("test1", sapBusinessPartner.ContactEmployees[0].Name);
+            Assert.Equal("test", sapBusinessPartner.ContactEmployees[1].Name);
+        }
     }
 }

--- a/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForArMapper.cs
+++ b/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForArMapper.cs
@@ -83,38 +83,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
                 Indicator = "FC",
                 DunningTerm = "ReclamoVto",
                 FatherCard = fatherBusinessPartner?.CardCode,
-                ContactEmployees = (dopplerUser.BillingEmails != null && dopplerUser.BillingEmails[0] != String.Empty) ?
-                dopplerUser.BillingEmails
-                    .Select(x => new SapContactEmployee
-                    {
-                        Name = new MailAddress(x.ToLower()).User,
-                        E_Mail = x.ToLower(),
-                        CardCode = cardCode,
-                        Active = "tYES",
-                        EmailGroupCode = "Facturacion"
-                    })
-                    .Append(new SapContactEmployee
-                    {
-                        Name = new MailAddress(dopplerUser.Email.ToLower()).User,
-                        E_Mail = dopplerUser.Email.ToLower(),
-                        CardCode = cardCode,
-                        Active = "tYES",
-                        EmailGroupCode = "Facturacion"
-                    })
-                    .GroupBy(y => y.E_Mail)
-                    .Select(z => z.First())
-                    .ToList()
-                    : new List<SapContactEmployee>
-                        {
-                            new SapContactEmployee
-                                {
-                                    Name = new MailAddress(dopplerUser.Email.ToLower()).User,
-                                    E_Mail = dopplerUser.Email.ToLower(),
-                                        CardCode = cardCode,
-                                    Active = "tYES",
-                                    EmailGroupCode = "Facturacion"
-                                }
-                            },
+                ContactEmployees = GetContactEmployees(dopplerUser, cardCode, "Facturacion"),
                 BPAddresses = new List<Address>
                 {
                     new Address

--- a/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForUsMapper.cs
+++ b/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForUsMapper.cs
@@ -76,38 +76,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
                 U_DPL_SUSPENDED = dopplerUser.Blocked ? "Y" : "N",
                 SalesPersonCode = (dopplerUser.IsInbound.HasValue ? (dopplerUser.IsInbound.GetValueOrDefault() ? 1 : 2) : 3),
                 FatherCard = fatherBusinessPartner?.CardCode,
-                ContactEmployees = (dopplerUser.BillingEmails != null && dopplerUser.BillingEmails[0] != String.Empty) ?
-                dopplerUser.BillingEmails
-                    .Select(x => new SapContactEmployee
-                    {
-                        Name = new MailAddress(x.ToLower()).User,
-                        E_Mail = x.ToLower(),
-                        CardCode = cardCode,
-                        Active = "tYES",
-                        EmailGroupCode = "Billing"
-                    })
-                    .Append(new SapContactEmployee
-                    {
-                        Name = new MailAddress(dopplerUser.Email.ToLower()).User,
-                        E_Mail = dopplerUser.Email.ToLower(),
-                        CardCode = cardCode,
-                        Active = "tYES",
-                        EmailGroupCode = "Billing"
-                    })
-                    .GroupBy(y => y.E_Mail)
-                    .Select(z => z.First())
-                    .ToList()
-                    : new List<SapContactEmployee>
-                        {
-                            new SapContactEmployee
-                                {
-                                    Name = new MailAddress(dopplerUser.Email.ToLower()).User,
-                                    E_Mail = dopplerUser.Email.ToLower(),
-                                        CardCode = cardCode,
-                                    Active = "tYES",
-                                    EmailGroupCode = "Billing"
-                                }
-                            },
+                ContactEmployees = GetContactEmployees(dopplerUser, cardCode, "Billing"),
                 BPAddresses = new List<Address>
                 {
                     new Address


### PR DESCRIPTION
Rename contactId when the client has repeated contact id in the contacts because SAP throws an exception when the Business Partner has the same contact's name for two or more contacts.

Before:

``` ContactEmployees = new List<SapContactEmployee>
                    {
                        new SapContactEmployee
                        {
                            Name = "test",
                            E_Mail = "test@hotmail.com),
                            CardCode = "xxx",
                            Active = "tYES",
                            EmailGroupCode = 'Billing"
                        },
                       new SapContactEmployee
                        {
                            Name = "test",
                            E_Mail = "test@gmail.com),
                            CardCode = "xxx",
                            Active = "tYES",
                            EmailGroupCode = 'Billing"
                        }
                    };
```

After:

``` ContactEmployees = new List<SapContactEmployee>
                    {
                        new SapContactEmployee
                        {
                            Name = "test1",
                            E_Mail = "test@hotmail.com),
                            CardCode = "xxx",
                            Active = "tYES",
                            EmailGroupCode = 'Billing"
                        },
                       new SapContactEmployee
                        {
                            Name = "test2",
                            E_Mail = "test@gmail.com),
                            CardCode = "xxx",
                            Active = "tYES",
                            EmailGroupCode = 'Billing"
                        }
                    };
```

**Task:** [DAT-273](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-273)