### PR TITLE
[DAT-326] - calculate the fiscal type given a consumer type and federal tax id

### DIFF
--- a/Doppler.Sap.Test/Mappers/BusinessPartnerForArMapperTest.cs
+++ b/Doppler.Sap.Test/Mappers/BusinessPartnerForArMapperTest.cs
@@ -1,3 +1,4 @@
+using Doppler.Sap.Enums;
 using Doppler.Sap.Mappers.BusinessPartner;
 using Doppler.Sap.Models;
 using Xunit;
@@ -197,6 +198,82 @@ namespace Doppler.Sap.Test.Mappers
 
             Assert.Equal("test1", sapBusinessPartner.ContactEmployees[0].Name);
             Assert.Equal("test", sapBusinessPartner.ContactEmployees[1].Name);
+        }
+
+
+        [Fact]
+        public void BusinessPartnerForArMapper_ShouldBeSetDniInFiscalType_WhenTheClientIsCfAndHasADni()
+        {
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 2,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "123",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingEmails = new string[] { "test1@gmail.com" },
+                BillingSystemId = 2,
+                IdConsumerType = 1,
+            };
+
+            var mapper = new BusinessPartnerForArMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(((int)FiscalTypeEnum.DNI).ToString(), sapBusinessPartner.U_B1SYS_FiscIdType);
+        }
+
+        [Fact]
+        public void BusinessPartnerForArMapper_ShouldBeSetCuilInFiscalType_WhenTheClientIsCfAndHasACuil()
+        {
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 2,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "30126459870",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingEmails = new string[] { "test1@gmail.com" },
+                BillingSystemId = 2,
+                IdConsumerType = 1,
+            };
+
+            var mapper = new BusinessPartnerForArMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(((int)FiscalTypeEnum.CUIL).ToString(), sapBusinessPartner.U_B1SYS_FiscIdType);
+        }
+
+        [Fact]
+        public void BusinessPartnerForArMapper_ShouldBeSetCuitInFiscalType_WhenTheClientIsDifferentThatCf()
+        {
+            var dopplerUserDto = new DopplerUserDto
+            {
+                PlanType = 0,
+                IsClientManager = true,
+                ClientManagerType = 2,
+                PaymentMethod = 1,
+                FirstName = "Juan",
+                LastName = "Perez",
+                FederalTaxID = "30126459870",
+                BillingStateId = "01",
+                Email = "test@test.com",
+                BillingEmails = new string[] { "test1@gmail.com" },
+                BillingSystemId = 2,
+                IdConsumerType = 2,
+            };
+
+            var mapper = new BusinessPartnerForArMapper();
+            var sapBusinessPartner = mapper.MapDopplerUserToSapBusinessPartner(dopplerUserDto, "CD00001", null);
+
+            Assert.Equal(((int)FiscalTypeEnum.CUIT).ToString(), sapBusinessPartner.U_B1SYS_FiscIdType);
         }
     }
 }

--- a/Doppler.Sap/Enums/FiscalTypeEnum.cs
+++ b/Doppler.Sap/Enums/FiscalTypeEnum.cs
@@ -1,0 +1,9 @@
+namespace Doppler.Sap.Enums
+{
+    public enum FiscalTypeEnum
+    {
+        DNI = 96,
+        CUIL = 86,
+        CUIT = 80
+    }
+}

--- a/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForArMapper.cs
+++ b/Doppler.Sap/Mappers/BusinessPartner/BusinessPartnerForArMapper.cs
@@ -75,7 +75,7 @@ namespace Doppler.Sap.Mappers.BusinessPartner
                             : "CF",
                 Currency = fatherBusinessPartner?.Currency ?? "##",
                 AliasName = dopplerUser.Email.ToLower(),
-                U_B1SYS_FiscIdType = dopplerUser.FederalTaxType == "DNI" ? "96" : (dopplerUser.FederalTaxType == "CUIT" ? "80" : "99"),
+                U_B1SYS_FiscIdType = CalculateFiscalType(dopplerUser.IdConsumerType, dopplerUser.FederalTaxID.Replace("-", "")),
                 CardType = "C",
                 U_DPL_CANCELED = dopplerUser.Cancelated ? "Y" : "N",
                 U_DPL_SUSPENDED = dopplerUser.Blocked ? "Y" : "N",
@@ -134,6 +134,20 @@ namespace Doppler.Sap.Mappers.BusinessPartner
             }
 
             return newBusinessPartner;
+        }
+
+        private string CalculateFiscalType(int? idConsumerType, string federalTaxID)
+        {
+            var consumer = idConsumerType.HasValue ?
+                            (Dictionary.ConsumerTypesDictionary.TryGetValue(idConsumerType, out string consumerType) ? consumerType : "CF")
+                            : "CF";
+
+            if (consumer == "CF")
+            {
+                return (federalTaxID.Length <= 8 ? (int)FiscalTypeEnum.DNI : (int)FiscalTypeEnum.CUIL).ToString();
+            }
+
+            return ((int)FiscalTypeEnum.CUIT).ToString();
         }
     }
 }


### PR DESCRIPTION
Calculate the correct ```FiscalType``` given a ```idConsumerType and federalTaxId```. It change applies only for the SAP AR.

**Bug:** [DAT-326](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-326)