### PR TITLE
chore: include image name in version.txt

### DIFF
--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -181,7 +181,7 @@ fi
 
 docker build \
     -t "${imageName}:${canonicalTag}" \
-    --build-arg version="${versionFull}" \
+    --build-arg version="${imageName}:${canonicalTag}" \
     .
 
 if [ -n "${version}" ]


### PR DESCRIPTION
Replaces the version number in version.txt with the full canonical image name.

The idea is to apply the same approach in other repositories too.