### PR TITLE
[NO-TICKET] - Fix Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,5 +102,5 @@ def CHANGE_ID = env.CHANGE_ID
 // workaround https://issues.jenkins-ci.org/browse/JENKINS-55987
 // TODO: read this value from Jenkins provided metadata
 def String readCurrentTag() {
-    return sh(returnStdout: true, script: "git describe --tags --match v?*.?*.?* --abbrev=0 --exact-match || echo ''").trim()
+    return sh(returnStdout: true, script: 'echo ${TAG_NAME}').trim()
 }


### PR DESCRIPTION
Fix Jenkingsfile in order to fix some problems with the deployment, changing `readCurrentTag()` function:
```
def String readCurrentTag() {
    return sh(returnStdout: true, script: 'echo ${TAG_NAME}').trim()
}
```